### PR TITLE
Type safety

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,16 @@
+# https://www.dartlang.org/guides/language/analysis-options
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+
+# Source of linter options:
+# http://dart-lang.github.io/linter/lints/options/options.html
+linter:
+  rules:
+    - camel_case_types
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - unrelated_type_equality_checks
+    - valid_regexps

--- a/lib/factories/doublet_factory.dart
+++ b/lib/factories/doublet_factory.dart
@@ -11,14 +11,14 @@ abstract class Factory2<T, U> {
 
 }
 
-class Doublet<T, U> implements Factory2 {
+class Doublet<T, U> implements Factory2<T, U> {
 
   const Doublet();
 
   @override
-  Union2<T, U> first(first) => new Union2First<T, U>(first);
+  Union2<T, U> first(T first) => new Union2First<T, U>(first);
 
   @override
-  Union2<T, U> second(second) => new Union2Second<T, U>(second);
+  Union2<T, U> second(U second) => new Union2Second<T, U>(second);
 
 }

--- a/lib/factories/nonet_factory.dart
+++ b/lib/factories/nonet_factory.dart
@@ -11,7 +11,6 @@ import 'package:sealed_unions/union_9.dart';
 
 // Creator class for Union9
 abstract class Factory9<A, B, C, D, E, F, G, H, I> {
-
   Union9<A, B, C, D, E, F, G, H, I> first(A first);
 
   Union9<A, B, C, D, E, F, G, H, I> second(B second);
@@ -29,46 +28,45 @@ abstract class Factory9<A, B, C, D, E, F, G, H, I> {
   Union9<A, B, C, D, E, F, G, H, I> eighth(H eighth);
 
   Union9<A, B, C, D, E, F, G, H, I> ninth(I ninth);
-
 }
 
-class Nonet<A, B, C, D, E, F, G, H, I> implements Factory9 {
-
+class Nonet<A, B, C, D, E, F, G, H, I>
+    implements Factory9<A, B, C, D, E, F, G, H, I> {
   const Nonet();
 
   @override
-  Union9<A, B, C, D, E, F, G, H, I> first(first) =>
+  Union9<A, B, C, D, E, F, G, H, I> first(A first) =>
       new Union9First<A, B, C, D, E, F, G, H, I>(first);
 
   @override
-  Union9<A, B, C, D, E, F, G, H, I> second(second) =>
+  Union9<A, B, C, D, E, F, G, H, I> second(B second) =>
       new Union9Second<A, B, C, D, E, F, G, H, I>(second);
 
   @override
-  Union9<A, B, C, D, E, F, G, H, I> third(third) =>
+  Union9<A, B, C, D, E, F, G, H, I> third(C third) =>
       new Union9Third<A, B, C, D, E, F, G, H, I>(third);
 
   @override
-  Union9<A, B, C, D, E, F, G, H, I> fourth(fourth) =>
+  Union9<A, B, C, D, E, F, G, H, I> fourth(D fourth) =>
       new Union9Fourth<A, B, C, D, E, F, G, H, I>(fourth);
 
   @override
-  Union9<A, B, C, D, E, F, G, H, I> fifth(fifth) =>
+  Union9<A, B, C, D, E, F, G, H, I> fifth(E fifth) =>
       new Union9Fifth<A, B, C, D, E, F, G, H, I>(fifth);
 
   @override
-  Union9<A, B, C, D, E, F, G, H, I> sixth(sixth) =>
+  Union9<A, B, C, D, E, F, G, H, I> sixth(F sixth) =>
       new Union9Sixth<A, B, C, D, E, F, G, H, I>(sixth);
 
   @override
-  Union9<A, B, C, D, E, F, G, H, I> seventh(seventh) =>
+  Union9<A, B, C, D, E, F, G, H, I> seventh(G seventh) =>
       new Union9Seventh<A, B, C, D, E, F, G, H, I>(seventh);
 
   @override
-  Union9<A, B, C, D, E, F, G, H, I> eighth(eighth) =>
+  Union9<A, B, C, D, E, F, G, H, I> eighth(H eighth) =>
       new Union9Eighth<A, B, C, D, E, F, G, H, I>(eighth);
 
   @override
-  Union9<A, B, C, D, E, F, G, H, I> ninth(ninth) =>
+  Union9<A, B, C, D, E, F, G, H, I> ninth(I ninth) =>
       new Union9Ninth<A, B, C, D, E, F, G, H, I>(ninth);
 }

--- a/lib/factories/nullet_factory.dart
+++ b/lib/factories/nullet_factory.dart
@@ -10,11 +10,11 @@ abstract class Factory0<Result> {
   Union0<Result> first(Result result);
 }
 
-class Nullet<Result> implements Factory0 {
+class Nullet<Result> implements Factory0<Result> {
 
   const Nullet();
 
   @override
-  Union0 first(result) => new Union0First<Result>(result);
+  Union0<Result> first(Result result) => new Union0First<Result>(result);
 
 }

--- a/lib/factories/octet_factory.dart
+++ b/lib/factories/octet_factory.dart
@@ -29,40 +29,40 @@ abstract class Factory8<A, B, C, D, E, F, G, H> {
 
 }
 
-class Octet<A, B, C, D, E, F, G, H> implements Factory8 {
+class Octet<A, B, C, D, E, F, G, H> implements Factory8<A, B, C, D, E, F, G, H> {
 
   const Octet();
 
   @override
-  Union8<A, B, C, D, E, F, G, H> first(first) =>
+  Union8<A, B, C, D, E, F, G, H> first(A first) =>
       new Union8First<A, B, C, D, E, F, G, H>(first);
 
   @override
-  Union8<A, B, C, D, E, F, G, H> second(second) =>
+  Union8<A, B, C, D, E, F, G, H> second(B second) =>
       new Union8Second<A, B, C, D, E, F, G, H>(second);
 
   @override
-  Union8<A, B, C, D, E, F, G, H> third(third) =>
+  Union8<A, B, C, D, E, F, G, H> third(C third) =>
       new Union8Third<A, B, C, D, E, F, G, H>(third);
 
   @override
-  Union8<A, B, C, D, E, F, G, H> fourth(fourth) =>
+  Union8<A, B, C, D, E, F, G, H> fourth(D fourth) =>
       new Union8Fourth<A, B, C, D, E, F, G, H>(fourth);
 
   @override
-  Union8<A, B, C, D, E, F, G, H> fifth(fifth) =>
+  Union8<A, B, C, D, E, F, G, H> fifth(E fifth) =>
       new Union8Fifth<A, B, C, D, E, F, G, H>(fifth);
 
   @override
-  Union8<A, B, C, D, E, F, G, H> sixth(sixth) =>
+  Union8<A, B, C, D, E, F, G, H> sixth(F sixth) =>
       new Union8Sixth<A, B, C, D, E, F, G, H>(sixth);
 
   @override
-  Union8<A, B, C, D, E, F, G, H> seventh(seventh) =>
+  Union8<A, B, C, D, E, F, G, H> seventh(G seventh) =>
       new Union8Seventh<A, B, C, D, E, F, G, H>(seventh);
 
   @override
-  Union8<A, B, C, D, E, F, G, H> eighth(eighth) =>
+  Union8<A, B, C, D, E, F, G, H> eighth(H eighth) =>
       new Union8Eighth<A, B, C, D, E, F, G, H>(eighth);
 
 }

--- a/lib/factories/quartet_factory.dart
+++ b/lib/factories/quartet_factory.dart
@@ -17,20 +17,20 @@ abstract class Factory4<A, B, C, D> {
 
 }
 
-class Quartet<A, B, C, D> implements Factory4 {
+class Quartet<A, B, C, D> implements Factory4<A, B, C, D> {
 
   const Quartet();
 
   @override
-  Union4<A, B, C, D> first(first) => new Union4First<A, B, C, D>(first);
+  Union4<A, B, C, D> first(A first) => new Union4First<A, B, C, D>(first);
 
   @override
-  Union4<A, B, C, D> second(second) => new Union4Second<A, B, C, D>(second);
+  Union4<A, B, C, D> second(B second) => new Union4Second<A, B, C, D>(second);
 
   @override
-  Union4<A, B, C, D> third(third) => new Union4Third<A, B, C, D>(third);
+  Union4<A, B, C, D> third(C third) => new Union4Third<A, B, C, D>(third);
 
   @override
-  Union4<A, B, C, D> fourth(fourth) => new Union4Fourth<A, B, C, D>(fourth);
+  Union4<A, B, C, D> fourth(D fourth) => new Union4Fourth<A, B, C, D>(fourth);
 
 }

--- a/lib/factories/quintet_factory.dart
+++ b/lib/factories/quintet_factory.dart
@@ -20,25 +20,25 @@ abstract class Factory5<A, B, C, D, E> {
 
 }
 
-class Quintet<A, B, C, D, E> implements Factory5 {
+class Quintet<A, B, C, D, E> implements Factory5<A, B, C, D, E> {
 
   const Quintet();
 
   @override
-  Union5<A, B, C, D, E> first(first) => new Union5First<A, B, C, D, E>(first);
+  Union5<A, B, C, D, E> first(A first) => new Union5First<A, B, C, D, E>(first);
 
   @override
-  Union5<A, B, C, D, E> second(second) =>
+  Union5<A, B, C, D, E> second(B second) =>
       new Union5Second<A, B, C, D, E>(second);
 
   @override
-  Union5<A, B, C, D, E> third(third) => new Union5Third<A, B, C, D, E>(third);
+  Union5<A, B, C, D, E> third(C third) => new Union5Third<A, B, C, D, E>(third);
 
   @override
-  Union5<A, B, C, D, E> fourth(fourth) =>
+  Union5<A, B, C, D, E> fourth(D fourth) =>
       new Union5Fourth<A, B, C, D, E>(fourth);
 
   @override
-  Union5<A, B, C, D, E> fifth(fifth) => new Union5Fifth<A, B, C, D, E>(fifth);
+  Union5<A, B, C, D, E> fifth(E fifth) => new Union5Fifth<A, B, C, D, E>(fifth);
 
 }

--- a/lib/factories/septet_factory.dart
+++ b/lib/factories/septet_factory.dart
@@ -26,36 +26,36 @@ abstract class Factory7<A, B, C, D, E, F, G> {
 
 }
 
-class Septet<A, B, C, D, E, F, G> implements Factory7 {
+class Septet<A, B, C, D, E, F, G> implements Factory7<A, B, C, D, E, F, G> {
 
   const Septet();
 
   @override
-  Union7<A, B, C, D, E, F, G> first(first) =>
+  Union7<A, B, C, D, E, F, G> first(A first) =>
       new Union7First<A, B, C, D, E, F, G>(first);
 
   @override
-  Union7<A, B, C, D, E, F, G> second(second) =>
+  Union7<A, B, C, D, E, F, G> second(B second) =>
       new Union7Second<A, B, C, D, E, F, G>(second);
 
   @override
-  Union7<A, B, C, D, E, F, G> third(third) =>
+  Union7<A, B, C, D, E, F, G> third(C third) =>
       new Union7Third<A, B, C, D, E, F, G>(third);
 
   @override
-  Union7<A, B, C, D, E, F, G> fourth(fourth) =>
+  Union7<A, B, C, D, E, F, G> fourth(D fourth) =>
       new Union7Fourth<A, B, C, D, E, F, G>(fourth);
 
   @override
-  Union7<A, B, C, D, E, F, G> fifth(fifth) =>
+  Union7<A, B, C, D, E, F, G> fifth(E fifth) =>
       new Union7Fifth<A, B, C, D, E, F, G>(fifth);
 
   @override
-  Union7<A, B, C, D, E, F, G> sixth(sixth) =>
+  Union7<A, B, C, D, E, F, G> sixth(F sixth) =>
       new Union7Sixth<A, B, C, D, E, F, G>(sixth);
 
   @override
-  Union7<A, B, C, D, E, F, G> seventh(seventh) =>
+  Union7<A, B, C, D, E, F, G> seventh(G seventh) =>
       new Union7Seventh<A, B, C, D, E, F, G>(seventh);
 
 }

--- a/lib/factories/sextet_factory.dart
+++ b/lib/factories/sextet_factory.dart
@@ -23,7 +23,7 @@ abstract class Factory6<A, B, C, D, E, F> {
 
 }
 
-class Sextet<A, B, C, D, E, F> implements Factory6 {
+class Sextet<A, B, C, D, E, F> implements Factory6<A, B, C, D, E, F> {
 
   Sextet();
 

--- a/lib/factories/sextet_factory.dart
+++ b/lib/factories/sextet_factory.dart
@@ -28,27 +28,27 @@ class Sextet<A, B, C, D, E, F> implements Factory6<A, B, C, D, E, F> {
   Sextet();
 
   @override
-  Union6<A, B, C, D, E, F> first(first) =>
+  Union6<A, B, C, D, E, F> first(A first) =>
       new Union6First<A, B, C, D, E, F>(first);
 
   @override
-  Union6<A, B, C, D, E, F> second(second) =>
+  Union6<A, B, C, D, E, F> second(B second) =>
       new Union6Second<A, B, C, D, E, F>(second);
 
   @override
-  Union6<A, B, C, D, E, F> third(third) =>
+  Union6<A, B, C, D, E, F> third(C third) =>
       new Union6Third<A, B, C, D, E, F>(third);
 
   @override
-  Union6<A, B, C, D, E, F> fourth(fourth) =>
+  Union6<A, B, C, D, E, F> fourth(D fourth) =>
       new Union6Fourth<A, B, C, D, E, F>(fourth);
 
   @override
-  Union6<A, B, C, D, E, F> fifth(fifth) =>
+  Union6<A, B, C, D, E, F> fifth(E fifth) =>
       new Union6Fifth<A, B, C, D, E, F>(fifth);
 
   @override
-  Union6<A, B, C, D, E, F> sixth(sixth) =>
+  Union6<A, B, C, D, E, F> sixth(F sixth) =>
       new Union6Sixth<A, B, C, D, E, F>(sixth);
 
 }

--- a/lib/factories/singlet_factory.dart
+++ b/lib/factories/singlet_factory.dart
@@ -14,15 +14,15 @@ abstract class Factory1<Result> {
   Union1<Result> none();
 }
 
-class Singlet<Result> implements Factory1 {
+class Singlet<Result> implements Factory1<Result> {
 
   const Singlet();
 
   @override
-  Union1 first(result) => new Union1First<Result>(result);
+  Union1<Result> first(Result result) => new Union1First<Result>(result);
 
 
   @override
-  Union1 none() => new Union1None<Result>();
+  Union1<Result> none() => new Union1None<Result>();
 
 }

--- a/lib/factories/triplet_factory.dart
+++ b/lib/factories/triplet_factory.dart
@@ -14,7 +14,7 @@ abstract class Factory3<T, U, V> {
 
 }
 
-class Triplet<T, U, V> implements Factory3 {
+class Triplet<T, U, V> implements Factory3<T, U, V> {
 
   const Triplet();
 

--- a/lib/factories/triplet_factory.dart
+++ b/lib/factories/triplet_factory.dart
@@ -19,12 +19,12 @@ class Triplet<T, U, V> implements Factory3<T, U, V> {
   const Triplet();
 
   @override
-  Union3<T, U, V> first(first) => new Union3First<T, U, V>(first);
+  Union3<T, U, V> first(T first) => new Union3First<T, U, V>(first);
 
   @override
-  Union3<T, U, V> second(second) => new Union3Second<T, U, V>(second);
+  Union3<T, U, V> second(U second) => new Union3Second<T, U, V>(second);
 
   @override
-  Union3<T, U, V> third(third) => new Union3Third<T, U, V>(third);
+  Union3<T, U, V> third(V third) => new Union3Third<T, U, V>(third);
 
 }

--- a/lib/generic/union_0_first.dart
+++ b/lib/generic/union_0_first.dart
@@ -1,6 +1,5 @@
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_0.dart';
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
 
 class Union0First<T> implements Union0<T> {
 
@@ -9,12 +8,12 @@ class Union0First<T> implements Union0<T> {
   Union0First(this._value);
 
   @override
-  void continued(Consumer<T> continuationFirst) {
+  void continued(VoidFunc1<T> continuationFirst) {
     continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<R, T> mapFirst) => mapFirst(_value);
+  R join<R>(Func1<T, R> mapFirst) => mapFirst(_value);
 
   @override
   bool operator ==(Object other) =>

--- a/lib/generic/union_0_first.dart
+++ b/lib/generic/union_0_first.dart
@@ -1,6 +1,6 @@
 import 'package:sealed_unions/union_0.dart';
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 
 class Union0First<T> implements Union0<T> {
 
@@ -9,22 +9,12 @@ class Union0First<T> implements Union0<T> {
   Union0First(this._value);
 
   @override
-  void continued(VoidFunc1<T> continuationFirst) {
-    try {
-      continuationFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(Consumer<T> continuationFirst) {
+    continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst) {
-    try {
-      return mapFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
-  }
+  R join<R>(Func1<R, T> mapFirst) => mapFirst(_value);
 
   @override
   bool operator ==(Object other) =>

--- a/lib/generic/union_1_first.dart
+++ b/lib/generic/union_1_first.dart
@@ -1,6 +1,5 @@
-import 'package:sealed_unions/functions/func_action.dart';
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
+
 import 'package:sealed_unions/union_1.dart';
 
 class Union1First<T> implements Union1<T> {
@@ -9,12 +8,12 @@ class Union1First<T> implements Union1<T> {
   Union1First(this._value);
 
   @override
-  void continued(Consumer<T> continuationFirst, Action continuationNone) {
+  void continued(VoidFunc1<T> continuationFirst, VoidFunc0 continuationNone) {
     continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<R, T> mapFirst, Func0<R> mapNone) => mapFirst(_value);
+  R join<R>(Func1<T, R> mapFirst, Func0<R> mapNone) => mapFirst(_value);
 
   @override
   bool operator ==(Object other) =>

--- a/lib/generic/union_1_first.dart
+++ b/lib/generic/union_1_first.dart
@@ -1,37 +1,27 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_action.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_1.dart';
 
 class Union1First<T> implements Union1<T> {
-
   final T _value;
 
   Union1First(this._value);
 
   @override
-  void continued(VoidFunc1<T> continuationFirst, VoidFunc0 continuationNone) {
-    try {
-      continuationFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(Consumer<T> continuationFirst, Action continuationNone) {
+    continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func0<R> mapNone) {
-    try {
-      return mapFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
-  }
+  R join<R>(Func1<R, T> mapFirst, Func0<R> mapNone) => mapFirst(_value);
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union1First &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union1First &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;

--- a/lib/generic/union_1_none.dart
+++ b/lib/generic/union_1_none.dart
@@ -1,18 +1,16 @@
-import 'package:sealed_unions/functions/func_action.dart';
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_1.dart';
 
 class Union1None<T> implements Union1<T> {
   Union1None();
 
   @override
-  void continued(Consumer<T> continuationFirst, Action continuationNone) {
+  void continued(VoidFunc1<T> continuationFirst, VoidFunc0 continuationNone) {
     continuationNone();
   }
 
   @override
-  R join<R>(Func1<R, T> mapFirst, Func0<R> mapNone) => mapNone();
+  R join<R>(Func1<T, R> mapFirst, Func0<R> mapNone) => mapNone();
 
   @override
   bool operator ==(Object other) =>

--- a/lib/generic/union_1_none.dart
+++ b/lib/generic/union_1_none.dart
@@ -1,40 +1,27 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_action.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_1.dart';
 
 class Union1None<T> implements Union1<T> {
-
   Union1None();
 
   @override
-  void continued(VoidFunc1<T> continuationFirst, VoidFunc0 continuationNone) {
-    try {
-      continuationNone();
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(Consumer<T> continuationFirst, Action continuationNone) {
+    continuationNone();
   }
 
   @override
-  R join<R>(Func1<R, T> mapFirst, Func0<R> mapNone) {
-    try {
-      return mapNone();
-    } on Exception catch (e) {
-      rethrow;
-    }
-  }
-
+  R join<R>(Func1<R, T> mapFirst, Func0<R> mapNone) => mapNone();
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union1None &&
-              runtimeType == other.runtimeType;
+      other is Union1None && runtimeType == other.runtimeType;
 
   @override
   int get hashCode => 0;
 
   @override
   String toString() => "None()";
-
 }

--- a/lib/generic/union_2_first.dart
+++ b/lib/generic/union_2_first.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_2.dart';
 
 class Union2First<T, U> implements Union2<T, U> {
@@ -9,14 +8,14 @@ class Union2First<T, U> implements Union2<T, U> {
 
   @override
   void continued(
-    Consumer<T> continuationFirst,
-    Consumer<U> continuationSecond,
+    VoidFunc1<T> continuationFirst,
+    VoidFunc1<U> continuationSecond,
   ) {
     continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<R, T> mapFirst, Func1<R, U> mapSecond) => mapFirst(_value);
+  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond) => mapFirst(_value);
 
   @override
   bool operator ==(Object other) =>

--- a/lib/generic/union_2_first.dart
+++ b/lib/generic/union_2_first.dart
@@ -1,42 +1,33 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_2.dart';
 
 class Union2First<T, U> implements Union2<T, U> {
-
   final T _value;
 
   Union2First(this._value);
 
   @override
-  void continued(VoidFunc1<T> continuationFirst, VoidFunc1<U> continuationSecond) {
-    try {
-      continuationFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<T> continuationFirst,
+    Consumer<U> continuationSecond,
+  ) {
+    continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond) {
-    try {
-      return mapFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
-  }
+  R join<R>(Func1<R, T> mapFirst, Func1<R, U> mapSecond) => mapFirst(_value);
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union2First &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union2First &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_2_second.dart
+++ b/lib/generic/union_2_second.dart
@@ -1,43 +1,33 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_2.dart';
 
 class Union2Second<T, U> implements Union2<T, U> {
-
   final U _value;
 
   Union2Second(this._value);
 
   @override
-  void continued(VoidFunc1<T> continuationFirst,
-      VoidFunc1<U> continuationSecond) {
-    try {
-      continuationSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<T> continuationFirst,
+    Consumer<U> continuationSecond,
+  ) {
+    continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond) {
-    try {
-      return mapSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
-  }
+  R join<R>(Func1<R, T> mapFirst, Func1<R, U> mapSecond) => mapSecond(_value);
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union2Second &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union2Second &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_2_second.dart
+++ b/lib/generic/union_2_second.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_2.dart';
 
 class Union2Second<T, U> implements Union2<T, U> {
@@ -9,14 +8,14 @@ class Union2Second<T, U> implements Union2<T, U> {
 
   @override
   void continued(
-    Consumer<T> continuationFirst,
-    Consumer<U> continuationSecond,
+    VoidFunc1<T> continuationFirst,
+    VoidFunc1<U> continuationSecond,
   ) {
     continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<R, T> mapFirst, Func1<R, U> mapSecond) => mapSecond(_value);
+  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond) => mapSecond(_value);
 
   @override
   bool operator ==(Object other) =>

--- a/lib/generic/union_3_first.dart
+++ b/lib/generic/union_3_first.dart
@@ -1,43 +1,36 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_3.dart';
 
 class Union3First<T, U, V> implements Union3<T, U, V> {
-
   final T _value;
 
   Union3First(this._value);
 
   @override
-  void continued(VoidFunc1<T> continuationFirst, VoidFunc1<U> continuationSecond,
-      VoidFunc1<V> continuationThird) {
-    try {
-      continuationFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<T> continuationFirst,
+    Consumer<U> continuationSecond,
+    Consumer<V> continuationThird,
+  ) {
+    continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond, Func1<V, R> mapThird) {
-    try {
-      return mapFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(Func1<R, T> mapFirst, Func1<R, U> mapSecond, Func1<R, V> mapThird) {
+    return mapFirst(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union3First &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union3First &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_3_first.dart
+++ b/lib/generic/union_3_first.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_3.dart';
 
 class Union3First<T, U, V> implements Union3<T, U, V> {
@@ -9,15 +8,15 @@ class Union3First<T, U, V> implements Union3<T, U, V> {
 
   @override
   void continued(
-    Consumer<T> continuationFirst,
-    Consumer<U> continuationSecond,
-    Consumer<V> continuationThird,
+    VoidFunc1<T> continuationFirst,
+    VoidFunc1<U> continuationSecond,
+    VoidFunc1<V> continuationThird,
   ) {
     continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<R, T> mapFirst, Func1<R, U> mapSecond, Func1<R, V> mapThird) {
+  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond, Func1<V, R> mapThird) {
     return mapFirst(_value);
   }
 

--- a/lib/generic/union_3_second.dart
+++ b/lib/generic/union_3_second.dart
@@ -1,43 +1,33 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_3.dart';
 
 class Union3Second<T, U, V> implements Union3<T, U, V> {
-
   final U _value;
 
   Union3Second(this._value);
 
   @override
-  void continued(VoidFunc1<T> continuationFirst, VoidFunc1<U> continuationSecond,
-      VoidFunc1<V> continuationThird) {
-    try {
-      continuationSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(Consumer<T> continuationFirst, Consumer<U> continuationSecond,
+      Consumer<V> continuationThird) {
+    continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond, Func1<V, R> mapThird) {
-    try {
-      return mapSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(Func1<R, T> mapFirst, Func1<R, U> mapSecond, Func1<R, V> mapThird) {
+    return mapSecond(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union3Second &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union3Second &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_3_second.dart
+++ b/lib/generic/union_3_second.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_3.dart';
 
 class Union3Second<T, U, V> implements Union3<T, U, V> {
@@ -8,13 +7,16 @@ class Union3Second<T, U, V> implements Union3<T, U, V> {
   Union3Second(this._value);
 
   @override
-  void continued(Consumer<T> continuationFirst, Consumer<U> continuationSecond,
-      Consumer<V> continuationThird) {
+  void continued(
+    VoidFunc1<T> continuationFirst,
+    VoidFunc1<U> continuationSecond,
+    VoidFunc1<V> continuationThird,
+  ) {
     continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<R, T> mapFirst, Func1<R, U> mapSecond, Func1<R, V> mapThird) {
+  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond, Func1<V, R> mapThird) {
     return mapSecond(_value);
   }
 

--- a/lib/generic/union_3_third.dart
+++ b/lib/generic/union_3_third.dart
@@ -1,43 +1,36 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_3.dart';
 
 class Union3Third<T, U, V> implements Union3<T, U, V> {
-
   final V _value;
 
   Union3Third(this._value);
 
   @override
-  void continued(VoidFunc1<T> continuationFirst, VoidFunc1<U> continuationSecond,
-      VoidFunc1<V> continuationThird) {
-    try {
-      continuationThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<T> continuationFirst,
+    Consumer<U> continuationSecond,
+    Consumer<V> continuationThird,
+  ) {
+    continuationThird(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond, Func1<V, R> mapThird) {
-    try {
-      return mapThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(Func1<R, T> mapFirst, Func1<R, U> mapSecond, Func1<R, V> mapThird) {
+    return mapThird(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union3Third &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union3Third &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_3_third.dart
+++ b/lib/generic/union_3_third.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_3.dart';
 
 class Union3Third<T, U, V> implements Union3<T, U, V> {
@@ -9,15 +8,15 @@ class Union3Third<T, U, V> implements Union3<T, U, V> {
 
   @override
   void continued(
-    Consumer<T> continuationFirst,
-    Consumer<U> continuationSecond,
-    Consumer<V> continuationThird,
+    VoidFunc1<T> continuationFirst,
+    VoidFunc1<U> continuationSecond,
+    VoidFunc1<V> continuationThird,
   ) {
     continuationThird(_value);
   }
 
   @override
-  R join<R>(Func1<R, T> mapFirst, Func1<R, U> mapSecond, Func1<R, V> mapThird) {
+  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond, Func1<V, R> mapThird) {
     return mapThird(_value);
   }
 

--- a/lib/generic/union_4_first.dart
+++ b/lib/generic/union_4_first.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4First<A, B, C, D> implements Union4<A, B, C, D> {
@@ -9,20 +8,20 @@ class Union4First<A, B, C, D> implements Union4<A, B, C, D> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_4_first.dart
+++ b/lib/generic/union_4_first.dart
@@ -1,42 +1,42 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4First<A, B, C, D> implements Union4<A, B, C, D> {
-
   final A _value;
 
   Union4First(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth) {
-    try {
-      continuationFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+  ) {
+    continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth) {
-    try {
-      return mapFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+  ) {
+    return mapFirst(_value);
   }
 
   @override
   bool operator ==(Object other) =>
-      identical(this, other) || other is Union4First &&
-          runtimeType == other.runtimeType && _value == other._value;
+      identical(this, other) ||
+      other is Union4First &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_4_fourth.dart
+++ b/lib/generic/union_4_fourth.dart
@@ -1,44 +1,42 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4Fourth<A, B, C, D> implements Union4<A, B, C, D> {
-
   final D _value;
 
   Union4Fourth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth) {
-    try {
-      continuationFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+  ) {
+    continuationFourth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth) {
-    try {
-      return mapFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+  ) {
+    return mapFourth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union4Fourth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union4Fourth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_4_fourth.dart
+++ b/lib/generic/union_4_fourth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4Fourth<A, B, C, D> implements Union4<A, B, C, D> {
@@ -9,20 +8,20 @@ class Union4Fourth<A, B, C, D> implements Union4<A, B, C, D> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_4_second.dart
+++ b/lib/generic/union_4_second.dart
@@ -1,44 +1,42 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4Second<A, B, C, D> implements Union4<A, B, C, D> {
-
   final B _value;
 
   Union4Second(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth) {
-    try {
-      continuationSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+  ) {
+    continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth) {
-    try {
-      return mapSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+  ) {
+    return mapSecond(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union4Second &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union4Second &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_4_second.dart
+++ b/lib/generic/union_4_second.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4Second<A, B, C, D> implements Union4<A, B, C, D> {
@@ -9,20 +8,20 @@ class Union4Second<A, B, C, D> implements Union4<A, B, C, D> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_4_third.dart
+++ b/lib/generic/union_4_third.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4Third<A, B, C, D> implements Union4<A, B, C, D> {
@@ -9,20 +8,20 @@ class Union4Third<A, B, C, D> implements Union4<A, B, C, D> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
   ) {
     return mapThird(_value);
   }

--- a/lib/generic/union_4_third.dart
+++ b/lib/generic/union_4_third.dart
@@ -1,44 +1,42 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_4.dart';
 
-class Union4Third <A, B, C, D> implements Union4<A, B, C, D> {
-
+class Union4Third<A, B, C, D> implements Union4<A, B, C, D> {
   final C _value;
 
   Union4Third(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth) {
-    try {
-      continuationThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+  ) {
+    continuationThird(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth) {
-    try {
-      return mapThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+  ) {
+    return mapThird(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union4Third &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union4Third &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_5_fifth.dart
+++ b/lib/generic/union_5_fifth.dart
@@ -1,45 +1,44 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Fifth<A, B, C, D, E> implements Union5<A, B, C, D, E> {
-
   final E _value;
 
   Union5Fifth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth) {
-    try {
-      continuationFifth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+  ) {
+    continuationFifth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth) {
-    try {
-      return mapFifth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+  ) {
+    return mapFifth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union5Fifth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union5Fifth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_5_fifth.dart
+++ b/lib/generic/union_5_fifth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Fifth<A, B, C, D, E> implements Union5<A, B, C, D, E> {
@@ -9,22 +8,22 @@ class Union5Fifth<A, B, C, D, E> implements Union5<A, B, C, D, E> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
   ) {
     continuationFifth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
   ) {
     return mapFifth(_value);
   }

--- a/lib/generic/union_5_first.dart
+++ b/lib/generic/union_5_first.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5First<A, B, C, D, E> implements Union5<A, B, C, D, E> {
@@ -9,22 +8,22 @@ class Union5First<A, B, C, D, E> implements Union5<A, B, C, D, E> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_5_first.dart
+++ b/lib/generic/union_5_first.dart
@@ -1,45 +1,44 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5First<A, B, C, D, E> implements Union5<A, B, C, D, E> {
-
   final A _value;
 
   Union5First(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth) {
-    try {
-      continuationFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+  ) {
+    continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth) {
-    try {
-      return mapFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+  ) {
+    return mapFirst(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union5First &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union5First &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_5_fourth.dart
+++ b/lib/generic/union_5_fourth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Fourth<A, B, C, D, E> implements Union5<A, B, C, D, E> {
@@ -9,22 +8,22 @@ class Union5Fourth<A, B, C, D, E> implements Union5<A, B, C, D, E> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_5_fourth.dart
+++ b/lib/generic/union_5_fourth.dart
@@ -1,45 +1,44 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Fourth<A, B, C, D, E> implements Union5<A, B, C, D, E> {
-
   final D _value;
 
   Union5Fourth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth) {
-    try {
-      continuationFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+  ) {
+    continuationFourth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth) {
-    try {
-      return mapFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+  ) {
+    return mapFourth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union5Fourth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union5Fourth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_5_second.dart
+++ b/lib/generic/union_5_second.dart
@@ -1,45 +1,44 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Second<A, B, C, D, E> implements Union5<A, B, C, D, E> {
-
   final B _value;
 
   Union5Second(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth) {
-    try {
-      continuationSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+  ) {
+    continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth) {
-    try {
-      return mapSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+  ) {
+    return mapSecond(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union5Second &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union5Second &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_5_second.dart
+++ b/lib/generic/union_5_second.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Second<A, B, C, D, E> implements Union5<A, B, C, D, E> {
@@ -9,22 +8,22 @@ class Union5Second<A, B, C, D, E> implements Union5<A, B, C, D, E> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_5_third.dart
+++ b/lib/generic/union_5_third.dart
@@ -1,45 +1,44 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Third<A, B, C, D, E> implements Union5<A, B, C, D, E> {
-
   final C _value;
 
   Union5Third(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth) {
-    try {
-      continuationThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+  ) {
+    continuationThird(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth) {
-    try {
-      return mapThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+  ) {
+    return mapThird(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union5Third &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union5Third &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_5_third.dart
+++ b/lib/generic/union_5_third.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Third<A, B, C, D, E> implements Union5<A, B, C, D, E> {
@@ -9,22 +8,22 @@ class Union5Third<A, B, C, D, E> implements Union5<A, B, C, D, E> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
   ) {
     return mapThird(_value);
   }

--- a/lib/generic/union_6_fifth.dart
+++ b/lib/generic/union_6_fifth.dart
@@ -1,45 +1,46 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Fifth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
-
   final E _value;
 
   Union6Fifth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth) {
-    try {
-      continuationFifth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+  ) {
+    continuationFifth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth) {
-    try {
-      return mapFifth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+  ) {
+    return mapFifth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union6Fifth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union6Fifth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_6_fifth.dart
+++ b/lib/generic/union_6_fifth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Fifth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -9,24 +8,24 @@ class Union6Fifth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
   ) {
     continuationFifth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
   ) {
     return mapFifth(_value);
   }

--- a/lib/generic/union_6_first.dart
+++ b/lib/generic/union_6_first.dart
@@ -1,45 +1,46 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6First<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
-
   final A _value;
 
   Union6First(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth) {
-    try {
-      continuationFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+  ) {
+    continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth) {
-    try {
-      return mapFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+  ) {
+    return mapFirst(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union6First &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union6First &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_6_first.dart
+++ b/lib/generic/union_6_first.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6First<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -9,24 +8,24 @@ class Union6First<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_6_fourth.dart
+++ b/lib/generic/union_6_fourth.dart
@@ -1,45 +1,46 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Fourth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
-
   final D _value;
 
   Union6Fourth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth) {
-    try {
-      continuationFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+  ) {
+    continuationFourth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth) {
-    try {
-      return mapFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+  ) {
+    return mapFourth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union6Fourth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union6Fourth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_6_fourth.dart
+++ b/lib/generic/union_6_fourth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Fourth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -9,24 +8,24 @@ class Union6Fourth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_6_second.dart
+++ b/lib/generic/union_6_second.dart
@@ -1,45 +1,46 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Second<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
-
   final B _value;
 
   Union6Second(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth) {
-    try {
-      continuationSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+  ) {
+    continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth) {
-    try {
-      return mapSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+  ) {
+    return mapSecond(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union6Second &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union6Second &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_6_second.dart
+++ b/lib/generic/union_6_second.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Second<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -9,24 +8,24 @@ class Union6Second<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_6_sixth.dart
+++ b/lib/generic/union_6_sixth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Sixth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -9,24 +8,24 @@ class Union6Sixth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
   ) {
     continuationSixth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
   ) {
     return mapSixth(_value);
   }

--- a/lib/generic/union_6_sixth.dart
+++ b/lib/generic/union_6_sixth.dart
@@ -1,45 +1,46 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Sixth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
-
   final F _value;
 
   Union6Sixth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth) {
-    try {
-      continuationSixth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+  ) {
+    continuationSixth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth) {
-    try {
-      return mapSixth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+  ) {
+    return mapSixth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union6Sixth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union6Sixth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_6_third.dart
+++ b/lib/generic/union_6_third.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Third<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -9,24 +8,24 @@ class Union6Third<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
   ) {
     return mapThird(_value);
   }

--- a/lib/generic/union_6_third.dart
+++ b/lib/generic/union_6_third.dart
@@ -1,45 +1,46 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Third<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
-
   final C _value;
 
   Union6Third(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth) {
-    try {
-      continuationThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+  ) {
+    continuationThird(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth) {
-    try {
-      return mapThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+  ) {
+    return mapThird(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union6Third &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union6Third &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_7_fifth.dart
+++ b/lib/generic/union_7_fifth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Fifth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -9,26 +8,26 @@ class Union7Fifth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
   ) {
     continuationFifth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
   ) {
     return mapFifth(_value);
   }

--- a/lib/generic/union_7_fifth.dart
+++ b/lib/generic/union_7_fifth.dart
@@ -1,47 +1,48 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Fifth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
-
   final E _value;
 
   Union7Fifth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh) {
-    try {
-      continuationFifth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+  ) {
+    continuationFifth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh) {
-    try {
-      return mapFifth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+  ) {
+    return mapFifth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union7Fifth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union7Fifth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_7_first.dart
+++ b/lib/generic/union_7_first.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7First<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -9,26 +8,26 @@ class Union7First<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_7_first.dart
+++ b/lib/generic/union_7_first.dart
@@ -1,47 +1,48 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7First<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
-
   final A _value;
 
   Union7First(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh) {
-    try {
-      continuationFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+  ) {
+    continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh) {
-    try {
-      return mapFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+  ) {
+    return mapFirst(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union7First &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union7First &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_7_fourth.dart
+++ b/lib/generic/union_7_fourth.dart
@@ -1,47 +1,48 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Fourth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
-
   final D _value;
 
   Union7Fourth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh) {
-    try {
-      continuationFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+  ) {
+    continuationFourth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh) {
-    try {
-      return mapFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+  ) {
+    return mapFourth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union7Fourth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union7Fourth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_7_fourth.dart
+++ b/lib/generic/union_7_fourth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Fourth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -9,26 +8,26 @@ class Union7Fourth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_7_second.dart
+++ b/lib/generic/union_7_second.dart
@@ -1,47 +1,48 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Second<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
-
   final B _value;
 
   Union7Second(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh) {
-    try {
-      continuationSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+  ) {
+    continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh) {
-    try {
-      return mapSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+  ) {
+    return mapSecond(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union7Second &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union7Second &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_7_second.dart
+++ b/lib/generic/union_7_second.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Second<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -9,26 +8,26 @@ class Union7Second<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_7_seventh.dart
+++ b/lib/generic/union_7_seventh.dart
@@ -1,47 +1,49 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_7.dart';
 
-class Union7Seventh<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
-
+class Union7Seventh<A, B, C, D, E, F, G>
+    implements Union7<A, B, C, D, E, F, G> {
   final G _value;
 
   Union7Seventh(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh) {
-    try {
-      continuationSeventh(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+  ) {
+    continuationSeventh(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh) {
-    try {
-      return mapSeventh(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+  ) {
+    return mapSeventh(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union7Seventh &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union7Seventh &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_7_seventh.dart
+++ b/lib/generic/union_7_seventh.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Seventh<A, B, C, D, E, F, G>
@@ -10,26 +9,26 @@ class Union7Seventh<A, B, C, D, E, F, G>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
   ) {
     continuationSeventh(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
   ) {
     return mapSeventh(_value);
   }

--- a/lib/generic/union_7_sixth.dart
+++ b/lib/generic/union_7_sixth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Sixth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -9,26 +8,26 @@ class Union7Sixth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
   ) {
     continuationSixth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
   ) {
     return mapSixth(_value);
   }

--- a/lib/generic/union_7_sixth.dart
+++ b/lib/generic/union_7_sixth.dart
@@ -1,47 +1,48 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Sixth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
-
   final F _value;
 
   Union7Sixth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh) {
-    try {
-      continuationSixth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+  ) {
+    continuationSixth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh) {
-    try {
-      return mapSixth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+  ) {
+    return mapSixth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union7Sixth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union7Sixth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_7_third.dart
+++ b/lib/generic/union_7_third.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Third<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -9,26 +8,26 @@ class Union7Third<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
   ) {
     return mapThird(_value);
   }

--- a/lib/generic/union_7_third.dart
+++ b/lib/generic/union_7_third.dart
@@ -1,47 +1,48 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Third<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
-
   final C _value;
 
   Union7Third(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh) {
-    try {
-      continuationThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+  ) {
+    continuationThird(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh) {
-    try {
-      return mapThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+  ) {
+    return mapThird(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union7Third &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union7Third &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_8_eighth.dart
+++ b/lib/generic/union_8_eighth.dart
@@ -1,47 +1,51 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_8.dart';
 
-class Union8Eighth<A, B, C, D, E, F, G, H> implements Union8<A, B, C, D, E, F, G, H> {
-
+class Union8Eighth<A, B, C, D, E, F, G, H>
+    implements Union8<A, B, C, D, E, F, G, H> {
   final H _value;
 
   Union8Eighth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth) {
-    try {
-      continuationEighth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+  ) {
+    continuationEighth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth) {
-    try {
-      return mapEighth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+  ) {
+    return mapEighth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union8Eighth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union8Eighth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_8_eighth.dart
+++ b/lib/generic/union_8_eighth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Eighth<A, B, C, D, E, F, G, H>
@@ -10,28 +9,28 @@ class Union8Eighth<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
   ) {
     continuationEighth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
   ) {
     return mapEighth(_value);
   }

--- a/lib/generic/union_8_fifth.dart
+++ b/lib/generic/union_8_fifth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Fifth<A, B, C, D, E, F, G, H>
@@ -10,28 +9,28 @@ class Union8Fifth<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
   ) {
     continuationFifth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
   ) {
     return mapFifth(_value);
   }

--- a/lib/generic/union_8_fifth.dart
+++ b/lib/generic/union_8_fifth.dart
@@ -1,47 +1,51 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_8.dart';
 
-class Union8Fifth<A, B, C, D, E, F, G, H> implements Union8<A, B, C, D, E, F, G, H> {
-
+class Union8Fifth<A, B, C, D, E, F, G, H>
+    implements Union8<A, B, C, D, E, F, G, H> {
   final E _value;
 
   Union8Fifth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth) {
-    try {
-      continuationFifth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+  ) {
+    continuationFifth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth) {
-    try {
-      return mapFifth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+  ) {
+    return mapFifth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union8Fifth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union8Fifth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_8_first.dart
+++ b/lib/generic/union_8_first.dart
@@ -1,47 +1,51 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_8.dart';
 
-class Union8First<A, B, C, D, E, F, G, H> implements Union8<A, B, C, D, E, F, G, H> {
-
+class Union8First<A, B, C, D, E, F, G, H>
+    implements Union8<A, B, C, D, E, F, G, H> {
   final A _value;
 
   Union8First(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth) {
-    try {
-      continuationFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+  ) {
+    continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth) {
-    try {
-      return mapFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+  ) {
+    return mapFirst(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union8First &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union8First &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_8_first.dart
+++ b/lib/generic/union_8_first.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8First<A, B, C, D, E, F, G, H>
@@ -10,28 +9,28 @@ class Union8First<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_8_fourth.dart
+++ b/lib/generic/union_8_fourth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Fourth<A, B, C, D, E, F, G, H>
@@ -10,28 +9,28 @@ class Union8Fourth<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_8_fourth.dart
+++ b/lib/generic/union_8_fourth.dart
@@ -1,47 +1,51 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_8.dart';
 
-class Union8Fourth<A, B, C, D, E, F, G, H> implements Union8<A, B, C, D, E, F, G, H> {
-
+class Union8Fourth<A, B, C, D, E, F, G, H>
+    implements Union8<A, B, C, D, E, F, G, H> {
   final D _value;
 
   Union8Fourth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth) {
-    try {
-      continuationFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+  ) {
+    continuationFourth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth) {
-    try {
-      return mapFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+  ) {
+    return mapFourth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union8Fourth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union8Fourth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_8_second.dart
+++ b/lib/generic/union_8_second.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Second<A, B, C, D, E, F, G, H>
@@ -10,28 +9,28 @@ class Union8Second<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_8_second.dart
+++ b/lib/generic/union_8_second.dart
@@ -1,47 +1,51 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_8.dart';
 
-class Union8Second<A, B, C, D, E, F, G, H> implements Union8<A, B, C, D, E, F, G, H> {
-
+class Union8Second<A, B, C, D, E, F, G, H>
+    implements Union8<A, B, C, D, E, F, G, H> {
   final B _value;
 
   Union8Second(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth) {
-    try {
-      continuationSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+  ) {
+    continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth) {
-    try {
-      return mapSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+  ) {
+    return mapSecond(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union8Second &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union8Second &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_8_seventh.dart
+++ b/lib/generic/union_8_seventh.dart
@@ -1,47 +1,51 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_8.dart';
 
-class Union8Seventh<A, B, C, D, E, F, G, H> implements Union8<A, B, C, D, E, F, G, H> {
-
+class Union8Seventh<A, B, C, D, E, F, G, H>
+    implements Union8<A, B, C, D, E, F, G, H> {
   final G _value;
 
   Union8Seventh(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth) {
-    try {
-      continuationSeventh(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+  ) {
+    continuationSeventh(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth) {
-    try {
-      return mapSeventh(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+  ) {
+    return mapSeventh(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union8Seventh &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union8Seventh &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_8_seventh.dart
+++ b/lib/generic/union_8_seventh.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Seventh<A, B, C, D, E, F, G, H>
@@ -10,28 +9,28 @@ class Union8Seventh<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
   ) {
     continuationSeventh(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
   ) {
     return mapSeventh(_value);
   }

--- a/lib/generic/union_8_sixth.dart
+++ b/lib/generic/union_8_sixth.dart
@@ -1,47 +1,51 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_8.dart';
 
-class Union8Sixth<A, B, C, D, E, F, G, H> implements Union8<A, B, C, D, E, F, G, H> {
-
+class Union8Sixth<A, B, C, D, E, F, G, H>
+    implements Union8<A, B, C, D, E, F, G, H> {
   final F _value;
 
   Union8Sixth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth) {
-    try {
-      continuationSixth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+  ) {
+    continuationSixth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth) {
-    try {
-      return mapSixth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+  ) {
+    return mapSixth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union8Sixth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union8Sixth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_8_sixth.dart
+++ b/lib/generic/union_8_sixth.dart
@@ -1,5 +1,4 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Sixth<A, B, C, D, E, F, G, H>
@@ -10,28 +9,28 @@ class Union8Sixth<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
   ) {
     continuationSixth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
   ) {
     return mapSixth(_value);
   }

--- a/lib/generic/union_8_third.dart
+++ b/lib/generic/union_8_third.dart
@@ -1,47 +1,51 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_8.dart';
 
-class Union8Third<A, B, C, D, E, F, G, H> implements Union8<A, B, C, D, E, F, G, H> {
-
+class Union8Third<A, B, C, D, E, F, G, H>
+    implements Union8<A, B, C, D, E, F, G, H> {
   final C _value;
 
   Union8Third(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth) {
-    try {
-      continuationThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+  ) {
+    continuationThird(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth) {
-    try {
-      return mapThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+  ) {
+    return mapThird(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union8Third &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union8Third &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_8_third.dart
+++ b/lib/generic/union_8_third.dart
@@ -1,5 +1,5 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Third<A, B, C, D, E, F, G, H>
@@ -10,28 +10,28 @@ class Union8Third<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
   ) {
     return mapThird(_value);
   }

--- a/lib/generic/union_9_eighth.dart
+++ b/lib/generic/union_9_eighth.dart
@@ -1,48 +1,53 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_9.dart';
 
-class Union9Eighth<A, B, C, D, E, F, G, H, I> implements Union9<A, B, C, D, E, F, G, H, I> {
-
+class Union9Eighth<A, B, C, D, E, F, G, H, I>
+    implements Union9<A, B, C, D, E, F, G, H, I> {
   final H _value;
 
   Union9Eighth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth,
-      VoidFunc1<I> continuationNinth) {
-    try {
-      continuationEighth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+    Consumer<I> continuationNinth,
+  ) {
+    continuationEighth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth, Func1<I, R> mapNinth) {
-    try {
-      return mapEighth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+    Func1<R, I> mapNinth,
+  ) {
+    return mapEighth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union9Eighth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union9Eighth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_9_eighth.dart
+++ b/lib/generic/union_9_eighth.dart
@@ -1,5 +1,5 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Eighth<A, B, C, D, E, F, G, H, I>
@@ -10,30 +10,30 @@ class Union9Eighth<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
-    Consumer<I> continuationNinth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
+    VoidFunc1<I> continuationNinth,
   ) {
     continuationEighth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
-    Func1<R, I> mapNinth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
+    Func1<I, R> mapNinth,
   ) {
     return mapEighth(_value);
   }

--- a/lib/generic/union_9_fifth.dart
+++ b/lib/generic/union_9_fifth.dart
@@ -1,5 +1,5 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Fifth<A, B, C, D, E, F, G, H, I>
@@ -10,30 +10,30 @@ class Union9Fifth<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
-    Consumer<I> continuationNinth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
+    VoidFunc1<I> continuationNinth,
   ) {
     continuationFifth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
-    Func1<R, I> mapNinth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
+    Func1<I, R> mapNinth,
   ) {
     return mapFifth(_value);
   }

--- a/lib/generic/union_9_fifth.dart
+++ b/lib/generic/union_9_fifth.dart
@@ -1,48 +1,53 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_9.dart';
 
-class Union9Fifth<A, B, C, D, E, F, G, H, I> implements Union9<A, B, C, D, E, F, G, H, I> {
-
+class Union9Fifth<A, B, C, D, E, F, G, H, I>
+    implements Union9<A, B, C, D, E, F, G, H, I> {
   final E _value;
 
   Union9Fifth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth,
-      VoidFunc1<I> continuationNinth) {
-    try {
-      continuationFifth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+    Consumer<I> continuationNinth,
+  ) {
+    continuationFifth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth, Func1<I, R> mapNinth) {
-    try {
-      return mapFifth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+    Func1<R, I> mapNinth,
+  ) {
+    return mapFifth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union9Fifth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union9Fifth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_9_first.dart
+++ b/lib/generic/union_9_first.dart
@@ -1,48 +1,53 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_9.dart';
 
-class Union9First<A, B, C, D, E, F, G, H, I> implements Union9<A, B, C, D, E, F, G, H, I> {
-
+class Union9First<A, B, C, D, E, F, G, H, I>
+    implements Union9<A, B, C, D, E, F, G, H, I> {
   final A _value;
 
   Union9First(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth,
-      VoidFunc1<I> continuationNinth) {
-    try {
-      continuationFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+    Consumer<I> continuationNinth,
+  ) {
+    continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth, Func1<I, R> mapNinth) {
-    try {
-      return mapFirst(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+    Func1<R, I> mapNinth,
+  ) {
+    return mapFirst(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union9First &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union9First &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_9_first.dart
+++ b/lib/generic/union_9_first.dart
@@ -1,5 +1,5 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9First<A, B, C, D, E, F, G, H, I>
@@ -10,30 +10,30 @@ class Union9First<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
-    Consumer<I> continuationNinth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
+    VoidFunc1<I> continuationNinth,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
-    Func1<R, I> mapNinth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
+    Func1<I, R> mapNinth,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_9_fourth.dart
+++ b/lib/generic/union_9_fourth.dart
@@ -1,48 +1,53 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_9.dart';
 
-class Union9Fourth<A, B, C, D, E, F, G, H, I> implements Union9<A, B, C, D, E, F, G, H, I> {
-
+class Union9Fourth<A, B, C, D, E, F, G, H, I>
+    implements Union9<A, B, C, D, E, F, G, H, I> {
   final D _value;
 
   Union9Fourth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth,
-      VoidFunc1<I> continuationNinth) {
-    try {
-      continuationFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+    Consumer<I> continuationNinth,
+  ) {
+    continuationFourth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth, Func1<I, R> mapNinth) {
-    try {
-      return mapFourth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+    Func1<R, I> mapNinth,
+  ) {
+    return mapFourth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union9Fourth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union9Fourth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_9_fourth.dart
+++ b/lib/generic/union_9_fourth.dart
@@ -1,5 +1,5 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Fourth<A, B, C, D, E, F, G, H, I>
@@ -10,30 +10,30 @@ class Union9Fourth<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
-    Consumer<I> continuationNinth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
+    VoidFunc1<I> continuationNinth,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
-    Func1<R, I> mapNinth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
+    Func1<I, R> mapNinth,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_9_ninth.dart
+++ b/lib/generic/union_9_ninth.dart
@@ -1,5 +1,5 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Ninth<A, B, C, D, E, F, G, H, I>
@@ -10,30 +10,30 @@ class Union9Ninth<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
-    Consumer<I> continuationNinth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
+    VoidFunc1<I> continuationNinth,
   ) {
     continuationNinth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
-    Func1<R, I> mapNinth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
+    Func1<I, R> mapNinth,
   ) {
     return mapNinth(_value);
   }

--- a/lib/generic/union_9_ninth.dart
+++ b/lib/generic/union_9_ninth.dart
@@ -1,48 +1,53 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_9.dart';
 
-class Union9Ninth<A, B, C, D, E, F, G, H, I> implements Union9<A, B, C, D, E, F, G, H, I> {
-
+class Union9Ninth<A, B, C, D, E, F, G, H, I>
+    implements Union9<A, B, C, D, E, F, G, H, I> {
   final I _value;
 
   Union9Ninth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth,
-      VoidFunc1<I> continuationNinth) {
-    try {
-      continuationNinth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+    Consumer<I> continuationNinth,
+  ) {
+    continuationNinth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth, Func1<I, R> mapNinth) {
-    try {
-      return mapNinth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+    Func1<R, I> mapNinth,
+  ) {
+    return mapNinth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union9Ninth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union9Ninth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_9_second.dart
+++ b/lib/generic/union_9_second.dart
@@ -1,48 +1,53 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_9.dart';
 
-class Union9Second<A, B, C, D, E, F, G, H, I> implements Union9<A, B, C, D, E, F, G, H, I> {
-
+class Union9Second<A, B, C, D, E, F, G, H, I>
+    implements Union9<A, B, C, D, E, F, G, H, I> {
   final B _value;
 
   Union9Second(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth,
-      VoidFunc1<I> continuationNinth) {
-    try {
-      continuationSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+    Consumer<I> continuationNinth,
+  ) {
+    continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth, Func1<I, R> mapNinth) {
-    try {
-      return mapSecond(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+    Func1<R, I> mapNinth,
+  ) {
+    return mapSecond(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union9Second &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union9Second &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_9_second.dart
+++ b/lib/generic/union_9_second.dart
@@ -1,5 +1,5 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Second<A, B, C, D, E, F, G, H, I>
@@ -10,30 +10,30 @@ class Union9Second<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
-    Consumer<I> continuationNinth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
+    VoidFunc1<I> continuationNinth,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
-    Func1<R, I> mapNinth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
+    Func1<I, R> mapNinth,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_9_seventh.dart
+++ b/lib/generic/union_9_seventh.dart
@@ -1,48 +1,53 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_9.dart';
 
-class Union9Seventh<A, B, C, D, E, F, G, H, I> implements Union9<A, B, C, D, E, F, G, H, I> {
-
+class Union9Seventh<A, B, C, D, E, F, G, H, I>
+    implements Union9<A, B, C, D, E, F, G, H, I> {
   final G _value;
 
   Union9Seventh(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth,
-      VoidFunc1<I> continuationNinth) {
-    try {
-      continuationSeventh(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+    Consumer<I> continuationNinth,
+  ) {
+    continuationSeventh(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth, Func1<I, R> mapNinth) {
-    try {
-      return mapSeventh(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+    Func1<R, I> mapNinth,
+  ) {
+    return mapSeventh(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union9Seventh &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union9Seventh &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_9_seventh.dart
+++ b/lib/generic/union_9_seventh.dart
@@ -1,5 +1,5 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Seventh<A, B, C, D, E, F, G, H, I>
@@ -10,30 +10,30 @@ class Union9Seventh<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
-    Consumer<I> continuationNinth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
+    VoidFunc1<I> continuationNinth,
   ) {
     continuationSeventh(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
-    Func1<R, I> mapNinth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
+    Func1<I, R> mapNinth,
   ) {
     return mapSeventh(_value);
   }

--- a/lib/generic/union_9_sixth.dart
+++ b/lib/generic/union_9_sixth.dart
@@ -1,48 +1,53 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_9.dart';
 
-class Union9Sixth<A, B, C, D, E, F, G, H, I> implements Union9<A, B, C, D, E, F, G, H, I> {
-
+class Union9Sixth<A, B, C, D, E, F, G, H, I>
+    implements Union9<A, B, C, D, E, F, G, H, I> {
   final F _value;
 
   Union9Sixth(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth,
-      VoidFunc1<I> continuationNinth) {
-    try {
-      continuationSixth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+    Consumer<I> continuationNinth,
+  ) {
+    continuationSixth(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth, Func1<I, R> mapNinth) {
-    try {
-      return mapSixth(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+    Func1<R, I> mapNinth,
+  ) {
+    return mapSixth(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union9Sixth &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union9Sixth &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/generic/union_9_sixth.dart
+++ b/lib/generic/union_9_sixth.dart
@@ -1,5 +1,5 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Sixth<A, B, C, D, E, F, G, H, I>
@@ -10,30 +10,30 @@ class Union9Sixth<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
-    Consumer<I> continuationNinth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
+    VoidFunc1<I> continuationNinth,
   ) {
     continuationSixth(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
-    Func1<R, I> mapNinth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
+    Func1<I, R> mapNinth,
   ) {
     return mapSixth(_value);
   }

--- a/lib/generic/union_9_third.dart
+++ b/lib/generic/union_9_third.dart
@@ -1,5 +1,5 @@
-import 'package:sealed_unions/functions/func_consumer.dart';
-import 'package:sealed_unions/functions/func_function.dart';
+
+import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Third<A, B, C, D, E, F, G, H, I>
@@ -10,30 +10,30 @@ class Union9Third<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    Consumer<A> continuationFirst,
-    Consumer<B> continuationSecond,
-    Consumer<C> continuationThird,
-    Consumer<D> continuationFourth,
-    Consumer<E> continuationFifth,
-    Consumer<F> continuationSixth,
-    Consumer<G> continuationSeventh,
-    Consumer<H> continuationEighth,
-    Consumer<I> continuationNinth,
+    VoidFunc1<A> continuationFirst,
+    VoidFunc1<B> continuationSecond,
+    VoidFunc1<C> continuationThird,
+    VoidFunc1<D> continuationFourth,
+    VoidFunc1<E> continuationFifth,
+    VoidFunc1<F> continuationSixth,
+    VoidFunc1<G> continuationSeventh,
+    VoidFunc1<H> continuationEighth,
+    VoidFunc1<I> continuationNinth,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<R, A> mapFirst,
-    Func1<R, B> mapSecond,
-    Func1<R, C> mapThird,
-    Func1<R, D> mapFourth,
-    Func1<R, E> mapFifth,
-    Func1<R, F> mapSixth,
-    Func1<R, G> mapSeventh,
-    Func1<R, H> mapEighth,
-    Func1<R, I> mapNinth,
+    Func1<A, R> mapFirst,
+    Func1<B, R> mapSecond,
+    Func1<C, R> mapThird,
+    Func1<D, R> mapFourth,
+    Func1<E, R> mapFifth,
+    Func1<F, R> mapSixth,
+    Func1<G, R> mapSeventh,
+    Func1<H, R> mapEighth,
+    Func1<I, R> mapNinth,
   ) {
     return mapThird(_value);
   }

--- a/lib/generic/union_9_third.dart
+++ b/lib/generic/union_9_third.dart
@@ -1,48 +1,53 @@
-
-import 'package:func/func.dart';
+import 'package:sealed_unions/functions/func_consumer.dart';
+import 'package:sealed_unions/functions/func_function.dart';
 import 'package:sealed_unions/union_9.dart';
 
-class Union9Third<A, B, C, D, E, F, G, H, I> implements Union9<A, B, C, D, E, F, G, H, I> {
-
+class Union9Third<A, B, C, D, E, F, G, H, I>
+    implements Union9<A, B, C, D, E, F, G, H, I> {
   final C _value;
 
   Union9Third(this._value);
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird, VoidFunc1<D> continuationFourth,
-      VoidFunc1<E> continuationFifth, VoidFunc1<F> continuationSixth,
-      VoidFunc1<G> continuationSeventh, VoidFunc1<H> continuationEighth,
-      VoidFunc1<I> continuationNinth) {
-    try {
-      continuationThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  void continued(
+    Consumer<A> continuationFirst,
+    Consumer<B> continuationSecond,
+    Consumer<C> continuationThird,
+    Consumer<D> continuationFourth,
+    Consumer<E> continuationFifth,
+    Consumer<F> continuationSixth,
+    Consumer<G> continuationSeventh,
+    Consumer<H> continuationEighth,
+    Consumer<I> continuationNinth,
+  ) {
+    continuationThird(_value);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth, Func1<I, R> mapNinth) {
-    try {
-      return mapThird(_value);
-    } on Exception catch (e) {
-      rethrow;
-    }
+  R join<R>(
+    Func1<R, A> mapFirst,
+    Func1<R, B> mapSecond,
+    Func1<R, C> mapThird,
+    Func1<R, D> mapFourth,
+    Func1<R, E> mapFifth,
+    Func1<R, F> mapSixth,
+    Func1<R, G> mapSeventh,
+    Func1<R, H> mapEighth,
+    Func1<R, I> mapNinth,
+  ) {
+    return mapThird(_value);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union9Third &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union9Third &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;
 
   @override
   String toString() => _value.toString();
-
 }

--- a/lib/union_1.dart
+++ b/lib/union_1.dart
@@ -1,8 +1,10 @@
 import 'package:func/func.dart';
 
-
 abstract class Union1<First> {
-  void continued(VoidFunc1<First> continuationFirst, VoidFunc0 continuationNone);
+  void continued(
+    VoidFunc1<First> continuationFirst,
+    VoidFunc0 continuationNone,
+  );
 
   R join<R>(Func1<First, R> mapFirst, Func0<R> mapNone);
 }

--- a/lib/union_2.dart
+++ b/lib/union_2.dart
@@ -1,10 +1,10 @@
 import 'package:func/func.dart';
 
-
-
 abstract class Union2<First, Second> {
-  void continued(VoidFunc1<First> continuationFirst,
-      VoidFunc1<Second> continuationSecond);
+  void continued(
+    VoidFunc1<First> continuationFirst,
+    VoidFunc1<Second> continuationSecond,
+  );
 
   R join<R>(Func1<First, R> mapFirst, Func1<Second, R> mapSecond);
 }

--- a/lib/union_3.dart
+++ b/lib/union_3.dart
@@ -1,11 +1,15 @@
 import 'package:func/func.dart';
 
-
-
 abstract class Union3<First, Second, Third> {
-   void continued(VoidFunc1<First> continuationFirst, VoidFunc1<Second> continuationSecond,
-      VoidFunc1<Third> continuationThird);
+  void continued(
+    VoidFunc1<First> continuationFirst,
+    VoidFunc1<Second> continuationSecond,
+    VoidFunc1<Third> continuationThird,
+  );
 
-  R join<R>(Func1<First, R> mapFirst, Func1<Second, R> mapSecond,
-      Func1<Third, R> mapThird);
+  R join<R>(
+    Func1<First, R> mapFirst,
+    Func1<Second, R> mapSecond,
+    Func1<Third, R> mapThird,
+  );
 }

--- a/lib/union_4.dart
+++ b/lib/union_4.dart
@@ -1,10 +1,17 @@
-
 import 'package:func/func.dart';
 
 abstract class Union4<First, Second, Third, Fourth> {
-  void continued(VoidFunc1<First> continuationFirst, VoidFunc1<Second> continuationSecond,
-      VoidFunc1<Third> continuationThird, VoidFunc1<Fourth> continuationFourth);
+  void continued(
+    VoidFunc1<First> continuationFirst,
+    VoidFunc1<Second> continuationSecond,
+    VoidFunc1<Third> continuationThird,
+    VoidFunc1<Fourth> continuationFourth,
+  );
 
-  R join<R>(Func1<First, R> mapFirst, Func1<Second, R> mapSecond,
-      Func1<Third, R> mapThird, Func1<Fourth, R> mapFourth);
+  R join<R>(
+    Func1<First, R> mapFirst,
+    Func1<Second, R> mapSecond,
+    Func1<Third, R> mapThird,
+    Func1<Fourth, R> mapFourth,
+  );
 }

--- a/lib/union_5.dart
+++ b/lib/union_5.dart
@@ -1,12 +1,19 @@
-
 import 'package:func/func.dart';
 
 abstract class Union5<First, Second, Third, Fourth, Fifth> {
-  void continued(VoidFunc1<First> continuationFirst, VoidFunc1<Second> continuationSecond,
-      VoidFunc1<Third> continuationThird, VoidFunc1<Fourth> continuationFourth,
-      VoidFunc1<Fifth> continuationFifth);
+  void continued(
+    VoidFunc1<First> continuationFirst,
+    VoidFunc1<Second> continuationSecond,
+    VoidFunc1<Third> continuationThird,
+    VoidFunc1<Fourth> continuationFourth,
+    VoidFunc1<Fifth> continuationFifth,
+  );
 
-  R join<R>(Func1<First, R> mapFirst, Func1<Second, R> mapSecond,
-      Func1<Third, R> mapThird, Func1<Fourth, R> mapFourth,
-      Func1<Fifth, R> mapFifth);
+  R join<R>(
+    Func1<First, R> mapFirst,
+    Func1<Second, R> mapSecond,
+    Func1<Third, R> mapThird,
+    Func1<Fourth, R> mapFourth,
+    Func1<Fifth, R> mapFifth,
+  );
 }

--- a/lib/union_6.dart
+++ b/lib/union_6.dart
@@ -1,12 +1,21 @@
-
 import 'package:func/func.dart';
 
 abstract class Union6<First, Second, Third, Fourth, Fifth, Sixth> {
-  void continued(VoidFunc1<First> continuationFirst, VoidFunc1<Second> continuationSecond,
-      VoidFunc1<Third> continuationThird, VoidFunc1<Fourth> continuationFourth,
-      VoidFunc1<Fifth> continuationFifth, VoidFunc1<Sixth> continuationSixth);
+  void continued(
+    VoidFunc1<First> continuationFirst,
+    VoidFunc1<Second> continuationSecond,
+    VoidFunc1<Third> continuationThird,
+    VoidFunc1<Fourth> continuationFourth,
+    VoidFunc1<Fifth> continuationFifth,
+    VoidFunc1<Sixth> continuationSixth,
+  );
 
-  R join<R>(Func1<First, R> mapFirst, Func1<Second, R> mapSecond,
-      Func1<Third, R> mapThird, Func1<Fourth, R> mapFourth, Func1<Fifth, R> mapFifth,
-      Func1<Sixth, R> mapSixth);
+  R join<R>(
+    Func1<First, R> mapFirst,
+    Func1<Second, R> mapSecond,
+    Func1<Third, R> mapThird,
+    Func1<Fourth, R> mapFourth,
+    Func1<Fifth, R> mapFifth,
+    Func1<Sixth, R> mapSixth,
+  );
 }

--- a/lib/union_7.dart
+++ b/lib/union_7.dart
@@ -1,13 +1,22 @@
-
 import 'package:func/func.dart';
 
 abstract class Union7<First, Second, Third, Fourth, Fifth, Sixth, Seventh> {
-  void continued(VoidFunc1<First> continuationFirst, VoidFunc1<Second> continuationSecond,
-      VoidFunc1<Third> continuationThird, VoidFunc1<Fourth> continuationFourth,
-      VoidFunc1<Fifth> continuationFifth, VoidFunc1<Sixth> continuationSixth,
+  void continued(
+      VoidFunc1<First> continuationFirst,
+      VoidFunc1<Second> continuationSecond,
+      VoidFunc1<Third> continuationThird,
+      VoidFunc1<Fourth> continuationFourth,
+      VoidFunc1<Fifth> continuationFifth,
+      VoidFunc1<Sixth> continuationSixth,
       VoidFunc1<Seventh> continuationSeventh);
 
-  R join<R>(Func1<First, R> mapFirst, Func1<Second, R> mapSecond,
-      Func1<Third, R> mapThird, Func1<Fourth, R> mapFourth, Func1<Fifth, R> mapFifth,
-      Func1<Sixth, R> mapSixth, Func1<Seventh, R> mapSeventh);
+  R join<R>(
+    Func1<First, R> mapFirst,
+    Func1<Second, R> mapSecond,
+    Func1<Third, R> mapThird,
+    Func1<Fourth, R> mapFourth,
+    Func1<Fifth, R> mapFifth,
+    Func1<Sixth, R> mapSixth,
+    Func1<Seventh, R> mapSeventh,
+  );
 }

--- a/lib/union_8.dart
+++ b/lib/union_8.dart
@@ -1,14 +1,26 @@
-
 import 'package:func/func.dart';
 
-abstract class Union8<First, Second, Third, Fourth, Fifth, Sixth, Seventh, Eighth> {
-  void continued(VoidFunc1<First> continuationFirst, VoidFunc1<Second> continuationSecond,
-      VoidFunc1<Third> continuationThird, VoidFunc1<Fourth> continuationFourth,
-      VoidFunc1<Fifth> continuationFifth, VoidFunc1<Sixth> continuationSixth,
-      VoidFunc1<Seventh> continuationSeventh, VoidFunc1<Eighth> continuationEighth);
+abstract class Union8<First, Second, Third, Fourth, Fifth, Sixth, Seventh,
+    Eighth> {
+  void continued(
+    VoidFunc1<First> continuationFirst,
+    VoidFunc1<Second> continuationSecond,
+    VoidFunc1<Third> continuationThird,
+    VoidFunc1<Fourth> continuationFourth,
+    VoidFunc1<Fifth> continuationFifth,
+    VoidFunc1<Sixth> continuationSixth,
+    VoidFunc1<Seventh> continuationSeventh,
+    VoidFunc1<Eighth> continuationEighth,
+  );
 
-  R join<R>(Func1<First, R> mapFirst, Func1<Second, R> mapSecond,
-      Func1<Third, R> mapThird, Func1<Fourth, R> mapFourth, Func1<Fifth, R> mapFifth,
-      Func1<Sixth, R> mapSixth, Func1<Seventh, R> mapSeventh,
-      Func1<Eighth, R> mapEighth);
+  R join<R>(
+    Func1<First, R> mapFirst,
+    Func1<Second, R> mapSecond,
+    Func1<Third, R> mapThird,
+    Func1<Fourth, R> mapFourth,
+    Func1<Fifth, R> mapFifth,
+    Func1<Sixth, R> mapSixth,
+    Func1<Seventh, R> mapSeventh,
+    Func1<Eighth, R> mapEighth,
+  );
 }

--- a/lib/union_9.dart
+++ b/lib/union_9.dart
@@ -1,15 +1,28 @@
-
 import 'package:func/func.dart';
 
-abstract class Union9<First, Second, Third, Fourth, Fifth, Sixth, Seventh, Eighth, Ninth> {
-  void continued(VoidFunc1<First> continuationFirst, VoidFunc1<Second> continuationSecond,
-      VoidFunc1<Third> continuationThird, VoidFunc1<Fourth> continuationFourth,
-      VoidFunc1<Fifth> continuationFifth, VoidFunc1<Sixth> continuationSixth,
-      VoidFunc1<Seventh> continuationSeventh, VoidFunc1<Eighth> continuationEighth,
-      VoidFunc1<Ninth> continuationNinth);
+abstract class Union9<First, Second, Third, Fourth, Fifth, Sixth, Seventh,
+    Eighth, Ninth> {
+  void continued(
+    VoidFunc1<First> continuationFirst,
+    VoidFunc1<Second> continuationSecond,
+    VoidFunc1<Third> continuationThird,
+    VoidFunc1<Fourth> continuationFourth,
+    VoidFunc1<Fifth> continuationFifth,
+    VoidFunc1<Sixth> continuationSixth,
+    VoidFunc1<Seventh> continuationSeventh,
+    VoidFunc1<Eighth> continuationEighth,
+    VoidFunc1<Ninth> continuationNinth,
+  );
 
-  R join<R>(Func1<First, R> mapFirst, Func1<Second, R> mapSecond,
-      Func1<Third, R> mapThird, Func1<Fourth, R> mapFourth, Func1<Fifth, R> mapFifth,
-      Func1<Sixth, R> mapSixth, Func1<Seventh, R> mapSeventh,
-      Func1<Eighth, R> mapEighth, Func1<Ninth, R> mapNinth);
+  R join<R>(
+    Func1<First, R> mapFirst,
+    Func1<Second, R> mapSecond,
+    Func1<Third, R> mapThird,
+    Func1<Fourth, R> mapFourth,
+    Func1<Fifth, R> mapFifth,
+    Func1<Sixth, R> mapSixth,
+    Func1<Seventh, R> mapSeventh,
+    Func1<Eighth, R> mapEighth,
+    Func1<Ninth, R> mapNinth,
+  );
 }

--- a/test/union_factories_test.dart
+++ b/test/union_factories_test.dart
@@ -17,12 +17,19 @@ const List<String>VALID_ARRAY = const[
   VALID, VALID, VALID, VALID, VALID, VALID, VALID, VALID, VALID, VALID
 ];
 
+<<<<<<< HEAD
 final Func1<int, String> VALUE = ([a]) => VALID;
 final Func1<int, String> EMPTY = ([a]) => INVALID;
 final VoidFunc1<int> SUCCESS = ([i])=>{};
 final VoidFunc1<int> ERROR = ([i]) => new StateError("");
+=======
+final Func1<String, int> VALUE = ([a]) => VALID;
+final Func1<String, int> EMPTY = ([a]) => INVALID;
+final Consumer<int> SUCCESS = ([i]) => "Success";
+final Consumer<int> ERROR = ([i]) => new StateError("");
+>>>>>>> Ensure the factory tests are up-to-speed with the new analysis options
 
-main() {
+void main() {
 
   group('Union Factories => test join ', () {
     Nullet<int> nullet = new Nullet();

--- a/test/union_factories_test.dart
+++ b/test/union_factories_test.dart
@@ -17,17 +17,10 @@ const List<String>VALID_ARRAY = const[
   VALID, VALID, VALID, VALID, VALID, VALID, VALID, VALID, VALID, VALID
 ];
 
-<<<<<<< HEAD
-final Func1<int, String> VALUE = ([a]) => VALID;
-final Func1<int, String> EMPTY = ([a]) => INVALID;
-final VoidFunc1<int> SUCCESS = ([i])=>{};
-final VoidFunc1<int> ERROR = ([i]) => new StateError("");
-=======
-final Func1<String, int> VALUE = ([a]) => VALID;
-final Func1<String, int> EMPTY = ([a]) => INVALID;
-final Consumer<int> SUCCESS = ([i]) => "Success";
-final Consumer<int> ERROR = ([i]) => new StateError("");
->>>>>>> Ensure the factory tests are up-to-speed with the new analysis options
+final Func1<int, String> VALUE = (a) => VALID;
+final Func1<int, String> EMPTY = (a) => INVALID;
+final VoidFunc1<int> SUCCESS = (i) => "Success";
+final VoidFunc1<int> ERROR = (i) => new StateError("");
 
 void main() {
 
@@ -60,7 +53,7 @@ void main() {
     });
 
     join1 = singlet.none().join(EMPTY, ()=>VALID);
-    join2 = doublet.second(0).join(([a])=>INVALID, ([a])=>VALID);
+    join2 = doublet.second(0).join((a)=>INVALID, (a)=>VALID);
     join3 = triplet.second(0).join(EMPTY, VALUE, EMPTY);
     join4 = quartet.second(0).join(EMPTY, VALUE, EMPTY, EMPTY);
     join5 = quintet.second(0).join(EMPTY, VALUE, EMPTY, EMPTY, EMPTY);


### PR DESCRIPTION
Hey hey :)

As I was using this lib, noticed a couple things:

  1. The `Nullet - Nonet` factories were not type safe (you could pass any object into the `first`, `second`, `third`, etc methods without seeing a  a type error)
  2. Confusing try / catch / rethrows. Seemed like the lib should simply call the function its given and throw normally if they cause an exception (fail fast).

This PR:

  * Adds an analysis_options.yaml file to enforce strong mode (for better type safety)
  * Adds more typing information to conform to strong mode on the factories
  * Removes unused try / catch blocks
  * Runs `dartfmt` on the files I touched
  
  