### PR TITLE
Version 3.0.0: Dart 2 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ pubspec.lock
 *.iml
 /coverage/
 *.log
+.dart_tool/
+android/
+ios/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.0
+
+* Support for Dart 2
+* Removed deprecated `func` package
+
 ## 2.0.0
 
 * Removed `functions` package in favour of [func](https://pub.dartlang.org/packages/func)

--- a/lib/factories/doublet_factory.dart
+++ b/lib/factories/doublet_factory.dart
@@ -4,15 +4,12 @@ import 'package:sealed_unions/union_2.dart';
 
 // Creator class for Union2
 abstract class Factory2<T, U> {
-
   Union2<T, U> first(T first);
 
   Union2<T, U> second(U second);
-
 }
 
 class Doublet<T, U> implements Factory2<T, U> {
-
   const Doublet();
 
   @override
@@ -20,5 +17,4 @@ class Doublet<T, U> implements Factory2<T, U> {
 
   @override
   Union2<T, U> second(U second) => new Union2Second<T, U>(second);
-
 }

--- a/lib/factories/nullet_factory.dart
+++ b/lib/factories/nullet_factory.dart
@@ -11,10 +11,8 @@ abstract class Factory0<Result> {
 }
 
 class Nullet<Result> implements Factory0<Result> {
-
   const Nullet();
 
   @override
   Union0<Result> first(Result result) => new Union0First<Result>(result);
-
 }

--- a/lib/factories/octet_factory.dart
+++ b/lib/factories/octet_factory.dart
@@ -10,7 +10,6 @@ import 'package:sealed_unions/union_8.dart';
 
 // Creator class for Union8
 abstract class Factory8<A, B, C, D, E, F, G, H> {
-
   Union8<A, B, C, D, E, F, G, H> first(A first);
 
   Union8<A, B, C, D, E, F, G, H> second(B second);
@@ -26,11 +25,10 @@ abstract class Factory8<A, B, C, D, E, F, G, H> {
   Union8<A, B, C, D, E, F, G, H> seventh(G seventh);
 
   Union8<A, B, C, D, E, F, G, H> eighth(H eighth);
-
 }
 
-class Octet<A, B, C, D, E, F, G, H> implements Factory8<A, B, C, D, E, F, G, H> {
-
+class Octet<A, B, C, D, E, F, G, H>
+    implements Factory8<A, B, C, D, E, F, G, H> {
   const Octet();
 
   @override
@@ -64,5 +62,4 @@ class Octet<A, B, C, D, E, F, G, H> implements Factory8<A, B, C, D, E, F, G, H> 
   @override
   Union8<A, B, C, D, E, F, G, H> eighth(H eighth) =>
       new Union8Eighth<A, B, C, D, E, F, G, H>(eighth);
-
 }

--- a/lib/factories/quartet_factory.dart
+++ b/lib/factories/quartet_factory.dart
@@ -6,7 +6,6 @@ import 'package:sealed_unions/union_4.dart';
 
 // Creator class for Union4
 abstract class Factory4<A, B, C, D> {
-
   Union4<A, B, C, D> first(A first);
 
   Union4<A, B, C, D> second(B second);
@@ -14,11 +13,9 @@ abstract class Factory4<A, B, C, D> {
   Union4<A, B, C, D> third(C third);
 
   Union4<A, B, C, D> fourth(D fourth);
-
 }
 
 class Quartet<A, B, C, D> implements Factory4<A, B, C, D> {
-
   const Quartet();
 
   @override
@@ -32,5 +29,4 @@ class Quartet<A, B, C, D> implements Factory4<A, B, C, D> {
 
   @override
   Union4<A, B, C, D> fourth(D fourth) => new Union4Fourth<A, B, C, D>(fourth);
-
 }

--- a/lib/factories/quintet_factory.dart
+++ b/lib/factories/quintet_factory.dart
@@ -7,7 +7,6 @@ import 'package:sealed_unions/union_5.dart';
 
 // Creator class for Union5
 abstract class Factory5<A, B, C, D, E> {
-
   Union5<A, B, C, D, E> first(A first);
 
   Union5<A, B, C, D, E> second(B second);
@@ -17,11 +16,9 @@ abstract class Factory5<A, B, C, D, E> {
   Union5<A, B, C, D, E> fourth(D fourth);
 
   Union5<A, B, C, D, E> fifth(E fifth);
-
 }
 
 class Quintet<A, B, C, D, E> implements Factory5<A, B, C, D, E> {
-
   const Quintet();
 
   @override
@@ -40,5 +37,4 @@ class Quintet<A, B, C, D, E> implements Factory5<A, B, C, D, E> {
 
   @override
   Union5<A, B, C, D, E> fifth(E fifth) => new Union5Fifth<A, B, C, D, E>(fifth);
-
 }

--- a/lib/factories/septet_factory.dart
+++ b/lib/factories/septet_factory.dart
@@ -9,7 +9,6 @@ import 'package:sealed_unions/union_7.dart';
 
 // Creator class for Union7
 abstract class Factory7<A, B, C, D, E, F, G> {
-
   Union7<A, B, C, D, E, F, G> first(A first);
 
   Union7<A, B, C, D, E, F, G> second(B second);
@@ -23,11 +22,9 @@ abstract class Factory7<A, B, C, D, E, F, G> {
   Union7<A, B, C, D, E, F, G> sixth(F sixth);
 
   Union7<A, B, C, D, E, F, G> seventh(G seventh);
-
 }
 
 class Septet<A, B, C, D, E, F, G> implements Factory7<A, B, C, D, E, F, G> {
-
   const Septet();
 
   @override
@@ -57,5 +54,4 @@ class Septet<A, B, C, D, E, F, G> implements Factory7<A, B, C, D, E, F, G> {
   @override
   Union7<A, B, C, D, E, F, G> seventh(G seventh) =>
       new Union7Seventh<A, B, C, D, E, F, G>(seventh);
-
 }

--- a/lib/factories/sextet_factory.dart
+++ b/lib/factories/sextet_factory.dart
@@ -8,7 +8,6 @@ import 'package:sealed_unions/union_6.dart';
 
 // Creator class for Union6
 abstract class Factory6<A, B, C, D, E, F> {
-
   Union6<A, B, C, D, E, F> first(A first);
 
   Union6<A, B, C, D, E, F> second(B second);
@@ -20,11 +19,9 @@ abstract class Factory6<A, B, C, D, E, F> {
   Union6<A, B, C, D, E, F> fifth(E fifth);
 
   Union6<A, B, C, D, E, F> sixth(F sixth);
-
 }
 
 class Sextet<A, B, C, D, E, F> implements Factory6<A, B, C, D, E, F> {
-
   Sextet();
 
   @override
@@ -50,5 +47,4 @@ class Sextet<A, B, C, D, E, F> implements Factory6<A, B, C, D, E, F> {
   @override
   Union6<A, B, C, D, E, F> sixth(F sixth) =>
       new Union6Sixth<A, B, C, D, E, F>(sixth);
-
 }

--- a/lib/factories/singlet_factory.dart
+++ b/lib/factories/singlet_factory.dart
@@ -15,14 +15,11 @@ abstract class Factory1<Result> {
 }
 
 class Singlet<Result> implements Factory1<Result> {
-
   const Singlet();
 
   @override
   Union1<Result> first(Result result) => new Union1First<Result>(result);
 
-
   @override
   Union1<Result> none() => new Union1None<Result>();
-
 }

--- a/lib/factories/triplet_factory.dart
+++ b/lib/factories/triplet_factory.dart
@@ -5,17 +5,14 @@ import 'package:sealed_unions/union_3.dart';
 
 // Creator class for Union3
 abstract class Factory3<T, U, V> {
-
   Union3<T, U, V> first(T first);
 
   Union3<T, U, V> second(U second);
 
   Union3<T, U, V> third(V third);
-
 }
 
 class Triplet<T, U, V> implements Factory3<T, U, V> {
-
   const Triplet();
 
   @override
@@ -26,5 +23,4 @@ class Triplet<T, U, V> implements Factory3<T, U, V> {
 
   @override
   Union3<T, U, V> third(V third) => new Union3Third<T, U, V>(third);
-
 }

--- a/lib/generic/union_0_first.dart
+++ b/lib/generic/union_0_first.dart
@@ -1,26 +1,24 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_0.dart';
 
 class Union0First<T> implements Union0<T> {
-
   final T _value;
 
   Union0First(this._value);
 
   @override
-  void continued(VoidFunc1<T> continuationFirst) {
+  void continued(Function(T) continuationFirst) {
     continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst) => mapFirst(_value);
+  R join<R>(R Function(T) mapFirst) => mapFirst(_value);
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union0First &&
-              runtimeType == other.runtimeType &&
-              _value == other._value;
+      other is Union0First &&
+          runtimeType == other.runtimeType &&
+          _value == other._value;
 
   @override
   int get hashCode => _value.hashCode;

--- a/lib/generic/union_1_first.dart
+++ b/lib/generic/union_1_first.dart
@@ -1,5 +1,3 @@
-import 'package:func/func.dart';
-
 import 'package:sealed_unions/union_1.dart';
 
 class Union1First<T> implements Union1<T> {
@@ -8,12 +6,12 @@ class Union1First<T> implements Union1<T> {
   Union1First(this._value);
 
   @override
-  void continued(VoidFunc1<T> continuationFirst, VoidFunc0 continuationNone) {
+  void continued(Function(T) continuationFirst, Function() continuationNone) {
     continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func0<R> mapNone) => mapFirst(_value);
+  R join<R>(R Function(T) mapFirst, R Function() mapNone) => mapFirst(_value);
 
   @override
   bool operator ==(Object other) =>

--- a/lib/generic/union_1_none.dart
+++ b/lib/generic/union_1_none.dart
@@ -1,16 +1,15 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_1.dart';
 
 class Union1None<T> implements Union1<T> {
   Union1None();
 
   @override
-  void continued(VoidFunc1<T> continuationFirst, VoidFunc0 continuationNone) {
+  void continued(Function(T) continuationFirst, Function() continuationNone) {
     continuationNone();
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func0<R> mapNone) => mapNone();
+  R join<R>(R Function(T) mapFirst, R Function() mapNone) => mapNone();
 
   @override
   bool operator ==(Object other) =>

--- a/lib/generic/union_2_first.dart
+++ b/lib/generic/union_2_first.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_2.dart';
 
 class Union2First<T, U> implements Union2<T, U> {
@@ -8,14 +7,15 @@ class Union2First<T, U> implements Union2<T, U> {
 
   @override
   void continued(
-    VoidFunc1<T> continuationFirst,
-    VoidFunc1<U> continuationSecond,
+    Function(T) continuationFirst,
+    Function(U) continuationSecond,
   ) {
     continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond) => mapFirst(_value);
+  R join<R>(R Function(T) mapFirst, R Function(U) mapSecond) =>
+      mapFirst(_value);
 
   @override
   bool operator ==(Object other) =>

--- a/lib/generic/union_2_second.dart
+++ b/lib/generic/union_2_second.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_2.dart';
 
 class Union2Second<T, U> implements Union2<T, U> {
@@ -8,14 +7,15 @@ class Union2Second<T, U> implements Union2<T, U> {
 
   @override
   void continued(
-    VoidFunc1<T> continuationFirst,
-    VoidFunc1<U> continuationSecond,
+    Function(T) continuationFirst,
+    Function(U) continuationSecond,
   ) {
     continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond) => mapSecond(_value);
+  R join<R>(R Function(T) mapFirst, R Function(U) mapSecond) =>
+      mapSecond(_value);
 
   @override
   bool operator ==(Object other) =>

--- a/lib/generic/union_3_first.dart
+++ b/lib/generic/union_3_first.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_3.dart';
 
 class Union3First<T, U, V> implements Union3<T, U, V> {
@@ -8,15 +7,16 @@ class Union3First<T, U, V> implements Union3<T, U, V> {
 
   @override
   void continued(
-    VoidFunc1<T> continuationFirst,
-    VoidFunc1<U> continuationSecond,
-    VoidFunc1<V> continuationThird,
+    Function(T) continuationFirst,
+    Function(U) continuationSecond,
+    Function(V) continuationThird,
   ) {
     continuationFirst(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond, Func1<V, R> mapThird) {
+  R join<R>(
+      R Function(T) mapFirst, R Function(U) mapSecond, R Function(V) mapThird) {
     return mapFirst(_value);
   }
 

--- a/lib/generic/union_3_second.dart
+++ b/lib/generic/union_3_second.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_3.dart';
 
 class Union3Second<T, U, V> implements Union3<T, U, V> {
@@ -8,15 +7,16 @@ class Union3Second<T, U, V> implements Union3<T, U, V> {
 
   @override
   void continued(
-    VoidFunc1<T> continuationFirst,
-    VoidFunc1<U> continuationSecond,
-    VoidFunc1<V> continuationThird,
+    Function(T) continuationFirst,
+    Function(U) continuationSecond,
+    Function(V) continuationThird,
   ) {
     continuationSecond(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond, Func1<V, R> mapThird) {
+  R join<R>(
+      R Function(T) mapFirst, R Function(U) mapSecond, R Function(V) mapThird) {
     return mapSecond(_value);
   }
 

--- a/lib/generic/union_3_third.dart
+++ b/lib/generic/union_3_third.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_3.dart';
 
 class Union3Third<T, U, V> implements Union3<T, U, V> {
@@ -8,15 +7,16 @@ class Union3Third<T, U, V> implements Union3<T, U, V> {
 
   @override
   void continued(
-    VoidFunc1<T> continuationFirst,
-    VoidFunc1<U> continuationSecond,
-    VoidFunc1<V> continuationThird,
+    Function(T) continuationFirst,
+    Function(U) continuationSecond,
+    Function(V) continuationThird,
   ) {
     continuationThird(_value);
   }
 
   @override
-  R join<R>(Func1<T, R> mapFirst, Func1<U, R> mapSecond, Func1<V, R> mapThird) {
+  R join<R>(
+      R Function(T) mapFirst, R Function(U) mapSecond, R Function(V) mapThird) {
     return mapThird(_value);
   }
 

--- a/lib/generic/union_4_first.dart
+++ b/lib/generic/union_4_first.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4First<A, B, C, D> implements Union4<A, B, C, D> {
@@ -8,20 +7,20 @@ class Union4First<A, B, C, D> implements Union4<A, B, C, D> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_4_fourth.dart
+++ b/lib/generic/union_4_fourth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4Fourth<A, B, C, D> implements Union4<A, B, C, D> {
@@ -8,20 +7,20 @@ class Union4Fourth<A, B, C, D> implements Union4<A, B, C, D> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_4_second.dart
+++ b/lib/generic/union_4_second.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4Second<A, B, C, D> implements Union4<A, B, C, D> {
@@ -8,20 +7,20 @@ class Union4Second<A, B, C, D> implements Union4<A, B, C, D> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_4_third.dart
+++ b/lib/generic/union_4_third.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4Third<A, B, C, D> implements Union4<A, B, C, D> {
@@ -8,20 +7,20 @@ class Union4Third<A, B, C, D> implements Union4<A, B, C, D> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
   ) {
     return mapThird(_value);
   }

--- a/lib/generic/union_5_fifth.dart
+++ b/lib/generic/union_5_fifth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Fifth<A, B, C, D, E> implements Union5<A, B, C, D, E> {
@@ -8,22 +7,22 @@ class Union5Fifth<A, B, C, D, E> implements Union5<A, B, C, D, E> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
   ) {
     continuationFifth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
   ) {
     return mapFifth(_value);
   }

--- a/lib/generic/union_5_first.dart
+++ b/lib/generic/union_5_first.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5First<A, B, C, D, E> implements Union5<A, B, C, D, E> {
@@ -8,22 +7,22 @@ class Union5First<A, B, C, D, E> implements Union5<A, B, C, D, E> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_5_fourth.dart
+++ b/lib/generic/union_5_fourth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Fourth<A, B, C, D, E> implements Union5<A, B, C, D, E> {
@@ -8,22 +7,22 @@ class Union5Fourth<A, B, C, D, E> implements Union5<A, B, C, D, E> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_5_second.dart
+++ b/lib/generic/union_5_second.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Second<A, B, C, D, E> implements Union5<A, B, C, D, E> {
@@ -8,22 +7,22 @@ class Union5Second<A, B, C, D, E> implements Union5<A, B, C, D, E> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_5_third.dart
+++ b/lib/generic/union_5_third.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Third<A, B, C, D, E> implements Union5<A, B, C, D, E> {
@@ -8,22 +7,22 @@ class Union5Third<A, B, C, D, E> implements Union5<A, B, C, D, E> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
   ) {
     return mapThird(_value);
   }

--- a/lib/generic/union_6_fifth.dart
+++ b/lib/generic/union_6_fifth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Fifth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -8,24 +7,24 @@ class Union6Fifth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
   ) {
     continuationFifth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
   ) {
     return mapFifth(_value);
   }

--- a/lib/generic/union_6_first.dart
+++ b/lib/generic/union_6_first.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6First<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -8,24 +7,24 @@ class Union6First<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_6_fourth.dart
+++ b/lib/generic/union_6_fourth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Fourth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -8,24 +7,24 @@ class Union6Fourth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_6_second.dart
+++ b/lib/generic/union_6_second.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Second<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -8,24 +7,24 @@ class Union6Second<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_6_sixth.dart
+++ b/lib/generic/union_6_sixth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Sixth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -8,24 +7,24 @@ class Union6Sixth<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
   ) {
     continuationSixth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
   ) {
     return mapSixth(_value);
   }

--- a/lib/generic/union_6_third.dart
+++ b/lib/generic/union_6_third.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Third<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -8,24 +7,24 @@ class Union6Third<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
   ) {
     return mapThird(_value);
   }

--- a/lib/generic/union_7_fifth.dart
+++ b/lib/generic/union_7_fifth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Fifth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -8,26 +7,26 @@ class Union7Fifth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
   ) {
     continuationFifth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
   ) {
     return mapFifth(_value);
   }

--- a/lib/generic/union_7_first.dart
+++ b/lib/generic/union_7_first.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7First<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -8,26 +7,26 @@ class Union7First<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_7_fourth.dart
+++ b/lib/generic/union_7_fourth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Fourth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -8,26 +7,26 @@ class Union7Fourth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_7_second.dart
+++ b/lib/generic/union_7_second.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Second<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -8,26 +7,26 @@ class Union7Second<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_7_seventh.dart
+++ b/lib/generic/union_7_seventh.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Seventh<A, B, C, D, E, F, G>
@@ -9,26 +8,26 @@ class Union7Seventh<A, B, C, D, E, F, G>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
   ) {
     continuationSeventh(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
   ) {
     return mapSeventh(_value);
   }

--- a/lib/generic/union_7_sixth.dart
+++ b/lib/generic/union_7_sixth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Sixth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -8,26 +7,26 @@ class Union7Sixth<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
   ) {
     continuationSixth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
   ) {
     return mapSixth(_value);
   }

--- a/lib/generic/union_7_third.dart
+++ b/lib/generic/union_7_third.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Third<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -8,26 +7,26 @@ class Union7Third<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
   ) {
     return mapThird(_value);
   }

--- a/lib/generic/union_8_eighth.dart
+++ b/lib/generic/union_8_eighth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Eighth<A, B, C, D, E, F, G, H>
@@ -9,28 +8,28 @@ class Union8Eighth<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
   ) {
     continuationEighth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
   ) {
     return mapEighth(_value);
   }

--- a/lib/generic/union_8_fifth.dart
+++ b/lib/generic/union_8_fifth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Fifth<A, B, C, D, E, F, G, H>
@@ -9,28 +8,28 @@ class Union8Fifth<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
   ) {
     continuationFifth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
   ) {
     return mapFifth(_value);
   }

--- a/lib/generic/union_8_first.dart
+++ b/lib/generic/union_8_first.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8First<A, B, C, D, E, F, G, H>
@@ -9,28 +8,28 @@ class Union8First<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_8_fourth.dart
+++ b/lib/generic/union_8_fourth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Fourth<A, B, C, D, E, F, G, H>
@@ -9,28 +8,28 @@ class Union8Fourth<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_8_second.dart
+++ b/lib/generic/union_8_second.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Second<A, B, C, D, E, F, G, H>
@@ -9,28 +8,28 @@ class Union8Second<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_8_seventh.dart
+++ b/lib/generic/union_8_seventh.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Seventh<A, B, C, D, E, F, G, H>
@@ -9,28 +8,28 @@ class Union8Seventh<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
   ) {
     continuationSeventh(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
   ) {
     return mapSeventh(_value);
   }

--- a/lib/generic/union_8_sixth.dart
+++ b/lib/generic/union_8_sixth.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Sixth<A, B, C, D, E, F, G, H>
@@ -9,28 +8,28 @@ class Union8Sixth<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
   ) {
     continuationSixth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
   ) {
     return mapSixth(_value);
   }

--- a/lib/generic/union_8_third.dart
+++ b/lib/generic/union_8_third.dart
@@ -1,5 +1,3 @@
-
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
 class Union8Third<A, B, C, D, E, F, G, H>
@@ -10,28 +8,28 @@ class Union8Third<A, B, C, D, E, F, G, H>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
   ) {
     return mapThird(_value);
   }

--- a/lib/generic/union_9_eighth.dart
+++ b/lib/generic/union_9_eighth.dart
@@ -1,5 +1,3 @@
-
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Eighth<A, B, C, D, E, F, G, H, I>
@@ -10,30 +8,30 @@ class Union9Eighth<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
-    VoidFunc1<I> continuationNinth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
+    Function(I) continuationNinth,
   ) {
     continuationEighth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
-    Func1<I, R> mapNinth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
+    R Function(I) mapNinth,
   ) {
     return mapEighth(_value);
   }

--- a/lib/generic/union_9_fifth.dart
+++ b/lib/generic/union_9_fifth.dart
@@ -1,5 +1,3 @@
-
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Fifth<A, B, C, D, E, F, G, H, I>
@@ -10,30 +8,30 @@ class Union9Fifth<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
-    VoidFunc1<I> continuationNinth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
+    Function(I) continuationNinth,
   ) {
     continuationFifth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
-    Func1<I, R> mapNinth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
+    R Function(I) mapNinth,
   ) {
     return mapFifth(_value);
   }

--- a/lib/generic/union_9_first.dart
+++ b/lib/generic/union_9_first.dart
@@ -1,5 +1,3 @@
-
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9First<A, B, C, D, E, F, G, H, I>
@@ -10,30 +8,30 @@ class Union9First<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
-    VoidFunc1<I> continuationNinth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
+    Function(I) continuationNinth,
   ) {
     continuationFirst(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
-    Func1<I, R> mapNinth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
+    R Function(I) mapNinth,
   ) {
     return mapFirst(_value);
   }

--- a/lib/generic/union_9_fourth.dart
+++ b/lib/generic/union_9_fourth.dart
@@ -1,5 +1,3 @@
-
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Fourth<A, B, C, D, E, F, G, H, I>
@@ -10,30 +8,30 @@ class Union9Fourth<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
-    VoidFunc1<I> continuationNinth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
+    Function(I) continuationNinth,
   ) {
     continuationFourth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
-    Func1<I, R> mapNinth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
+    R Function(I) mapNinth,
   ) {
     return mapFourth(_value);
   }

--- a/lib/generic/union_9_ninth.dart
+++ b/lib/generic/union_9_ninth.dart
@@ -1,5 +1,3 @@
-
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Ninth<A, B, C, D, E, F, G, H, I>
@@ -10,30 +8,30 @@ class Union9Ninth<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
-    VoidFunc1<I> continuationNinth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
+    Function(I) continuationNinth,
   ) {
     continuationNinth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
-    Func1<I, R> mapNinth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
+    R Function(I) mapNinth,
   ) {
     return mapNinth(_value);
   }

--- a/lib/generic/union_9_second.dart
+++ b/lib/generic/union_9_second.dart
@@ -1,5 +1,3 @@
-
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Second<A, B, C, D, E, F, G, H, I>
@@ -10,30 +8,30 @@ class Union9Second<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
-    VoidFunc1<I> continuationNinth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
+    Function(I) continuationNinth,
   ) {
     continuationSecond(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
-    Func1<I, R> mapNinth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
+    R Function(I) mapNinth,
   ) {
     return mapSecond(_value);
   }

--- a/lib/generic/union_9_seventh.dart
+++ b/lib/generic/union_9_seventh.dart
@@ -1,5 +1,3 @@
-
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Seventh<A, B, C, D, E, F, G, H, I>
@@ -10,30 +8,30 @@ class Union9Seventh<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
-    VoidFunc1<I> continuationNinth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
+    Function(I) continuationNinth,
   ) {
     continuationSeventh(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
-    Func1<I, R> mapNinth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
+    R Function(I) mapNinth,
   ) {
     return mapSeventh(_value);
   }

--- a/lib/generic/union_9_sixth.dart
+++ b/lib/generic/union_9_sixth.dart
@@ -1,5 +1,3 @@
-
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Sixth<A, B, C, D, E, F, G, H, I>
@@ -10,30 +8,30 @@ class Union9Sixth<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
-    VoidFunc1<I> continuationNinth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
+    Function(I) continuationNinth,
   ) {
     continuationSixth(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
-    Func1<I, R> mapNinth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
+    R Function(I) mapNinth,
   ) {
     return mapSixth(_value);
   }

--- a/lib/generic/union_9_third.dart
+++ b/lib/generic/union_9_third.dart
@@ -1,5 +1,3 @@
-
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Third<A, B, C, D, E, F, G, H, I>
@@ -10,30 +8,30 @@ class Union9Third<A, B, C, D, E, F, G, H, I>
 
   @override
   void continued(
-    VoidFunc1<A> continuationFirst,
-    VoidFunc1<B> continuationSecond,
-    VoidFunc1<C> continuationThird,
-    VoidFunc1<D> continuationFourth,
-    VoidFunc1<E> continuationFifth,
-    VoidFunc1<F> continuationSixth,
-    VoidFunc1<G> continuationSeventh,
-    VoidFunc1<H> continuationEighth,
-    VoidFunc1<I> continuationNinth,
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+    Function(F) continuationSixth,
+    Function(G) continuationSeventh,
+    Function(H) continuationEighth,
+    Function(I) continuationNinth,
   ) {
     continuationThird(_value);
   }
 
   @override
   R join<R>(
-    Func1<A, R> mapFirst,
-    Func1<B, R> mapSecond,
-    Func1<C, R> mapThird,
-    Func1<D, R> mapFourth,
-    Func1<E, R> mapFifth,
-    Func1<F, R> mapSixth,
-    Func1<G, R> mapSeventh,
-    Func1<H, R> mapEighth,
-    Func1<I, R> mapNinth,
+    R Function(A) mapFirst,
+    R Function(B) mapSecond,
+    R Function(C) mapThird,
+    R Function(D) mapFourth,
+    R Function(E) mapFifth,
+    R Function(F) mapSixth,
+    R Function(G) mapSeventh,
+    R Function(H) mapEighth,
+    R Function(I) mapNinth,
   ) {
     return mapThird(_value);
   }

--- a/lib/implementations/union_0_impl.dart
+++ b/lib/implementations/union_0_impl.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_0.dart';
 
 class Union0Impl<A> implements Union0<A> {
@@ -7,21 +6,21 @@ class Union0Impl<A> implements Union0<A> {
   Union0Impl(Union0<A> union) : _union = union;
 
   @override
-  void continued(VoidFunc1<A> continuationFirst) {
+  void continued(Function(A) continuationFirst) {
     _union.continued(continuationFirst);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst) {
+  R join<R>(R Function(A) mapFirst) {
     return _union.join(mapFirst);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union0Impl &&
-              runtimeType == other.runtimeType &&
-              _union == other._union;
+      other is Union0Impl &&
+          runtimeType == other.runtimeType &&
+          _union == other._union;
 
   @override
   int get hashCode => _union.hashCode;

--- a/lib/implementations/union_1_impl.dart
+++ b/lib/implementations/union_1_impl.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_1.dart';
 
 class Union1Impl<A> implements Union1<A> {
@@ -7,21 +6,21 @@ class Union1Impl<A> implements Union1<A> {
   Union1Impl(Union1<A> union) : _union = union;
 
   @override
-  void continued(VoidFunc1<A> continuationFirst, VoidFunc0 continuationNone) {
+  void continued(Function(A) continuationFirst, Function() continuationNone) {
     _union.continued(continuationFirst, continuationNone);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func0<R> mapNone) {
+  R join<R>(R Function(A) mapFirst, R Function() mapNone) {
     return _union.join(mapFirst, mapNone);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union1Impl &&
-              runtimeType == other.runtimeType &&
-              _union == other._union;
+      other is Union1Impl &&
+          runtimeType == other.runtimeType &&
+          _union == other._union;
 
   @override
   int get hashCode => _union.hashCode;

--- a/lib/implementations/union_2_impl.dart
+++ b/lib/implementations/union_2_impl.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_2.dart';
 
 class Union2Impl<A, B> implements Union2<A, B> {
@@ -7,22 +6,22 @@ class Union2Impl<A, B> implements Union2<A, B> {
   Union2Impl(Union2<A, B> union) : _union = union;
 
   @override
-  void continued(VoidFunc1<A> continuationFirst,
-      VoidFunc1<B> continuationSecond) {
+  void continued(
+      Function(A) continuationFirst, Function(B) continuationSecond) {
     _union.continued(continuationFirst, continuationSecond);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond) {
+  R join<R>(R Function(A) mapFirst, R Function(B) mapSecond) {
     return _union.join(mapFirst, mapSecond);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union2Impl &&
-              runtimeType == other.runtimeType &&
-              _union == other._union;
+      other is Union2Impl &&
+          runtimeType == other.runtimeType &&
+          _union == other._union;
 
   @override
   int get hashCode => _union.hashCode;

--- a/lib/implementations/union_3_impl.dart
+++ b/lib/implementations/union_3_impl.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_3.dart';
 
 class Union3Impl<A, B, C> implements Union3<A, B, C> {
@@ -7,23 +6,26 @@ class Union3Impl<A, B, C> implements Union3<A, B, C> {
   Union3Impl(Union3<A, B, C> union) : _union = union;
 
   @override
-  void continued(VoidFunc1<A> continuationFirst,
-      VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird,) {
+  void continued(
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+  ) {
     _union.continued(continuationFirst, continuationSecond, continuationThird);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird) {
+  R join<R>(
+      R Function(A) mapFirst, R Function(B) mapSecond, R Function(C) mapThird) {
     return _union.join(mapFirst, mapSecond, mapThird);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union3Impl &&
-              runtimeType == other.runtimeType &&
-              _union == other._union;
+      other is Union3Impl &&
+          runtimeType == other.runtimeType &&
+          _union == other._union;
 
   @override
   int get hashCode => _union.hashCode;

--- a/lib/implementations/union_4_impl.dart
+++ b/lib/implementations/union_4_impl.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_4.dart';
 
 class Union4Impl<A, B, C, D> implements Union4<A, B, C, D> {
@@ -7,26 +6,24 @@ class Union4Impl<A, B, C, D> implements Union4<A, B, C, D> {
   Union4Impl(Union4<A, B, C, D> union) : _union = union;
 
   @override
-  void continued(VoidFunc1<A> continuationFirst,
-      VoidFunc1<B> continuationSecond,
-      VoidFunc1<C> continuationThird,
-      VoidFunc1<D> continuationFourth) {
-    _union.continued(continuationFirst, continuationSecond,
-        continuationThird, continuationFourth);
+  void continued(Function(A) continuationFirst, Function(B) continuationSecond,
+      Function(C) continuationThird, Function(D) continuationFourth) {
+    _union.continued(continuationFirst, continuationSecond, continuationThird,
+        continuationFourth);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond,
-      Func1<C, R> mapThird, Func1<D, R> mapFourth) {
+  R join<R>(R Function(A) mapFirst, R Function(B) mapSecond,
+      R Function(C) mapThird, R Function(D) mapFourth) {
     return _union.join(mapFirst, mapSecond, mapThird, mapFourth);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union4Impl &&
-              runtimeType == other.runtimeType &&
-              _union == other._union;
+      other is Union4Impl &&
+          runtimeType == other.runtimeType &&
+          _union == other._union;
 
   @override
   int get hashCode => _union.hashCode;

--- a/lib/implementations/union_5_impl.dart
+++ b/lib/implementations/union_5_impl.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_5.dart';
 
 class Union5Impl<A, B, C, D, E> implements Union5<A, B, C, D, E> {
@@ -7,25 +6,29 @@ class Union5Impl<A, B, C, D, E> implements Union5<A, B, C, D, E> {
   Union5Impl(Union5<A, B, C, D, E> union) : _union = union;
 
   @override
-  void continued(VoidFunc1<A> continuationFirst,
-      VoidFunc1<B> continuationSecond, VoidFunc1<C> continuationThird,
-      VoidFunc1<D> continuationFourth, VoidFunc1<E> continuationFifth) {
+  void continued(
+    Function(A) continuationFirst,
+    Function(B) continuationSecond,
+    Function(C) continuationThird,
+    Function(D) continuationFourth,
+    Function(E) continuationFifth,
+  ) {
     _union.continued(continuationFirst, continuationSecond, continuationThird,
         continuationFourth, continuationFifth);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth) {
+  R join<R>(R Function(A) mapFirst, R Function(B) mapSecond,
+      R Function(C) mapThird, R Function(D) mapFourth, R Function(E) mapFifth) {
     return _union.join(mapFirst, mapSecond, mapThird, mapFourth, mapFifth);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union5Impl &&
-              runtimeType == other.runtimeType &&
-              _union == other._union;
+      other is Union5Impl &&
+          runtimeType == other.runtimeType &&
+          _union == other._union;
 
   @override
   int get hashCode => _union.hashCode;

--- a/lib/implementations/union_6_impl.dart
+++ b/lib/implementations/union_6_impl.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_6.dart';
 
 class Union6Impl<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
@@ -7,28 +6,35 @@ class Union6Impl<A, B, C, D, E, F> implements Union6<A, B, C, D, E, F> {
   Union6Impl(Union6<A, B, C, D, E, F> union) : _union = union;
 
   @override
-  void continued(VoidFunc1<A> continuationFirst,
-      VoidFunc1<B> continuationSecond, VoidFunc1<C> continuationThird,
-      VoidFunc1<D> continuationFourth, VoidFunc1<E> continuationFifth,
-      VoidFunc1<F> continuationSixth) {
+  void continued(
+      Function(A) continuationFirst,
+      Function(B) continuationSecond,
+      Function(C) continuationThird,
+      Function(D) continuationFourth,
+      Function(E) continuationFifth,
+      Function(F) continuationSixth) {
     _union.continued(continuationFirst, continuationSecond, continuationThird,
         continuationFourth, continuationFifth, continuationSixth);
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth) {
+  R join<R>(
+      R Function(A) mapFirst,
+      R Function(B) mapSecond,
+      R Function(C) mapThird,
+      R Function(D) mapFourth,
+      R Function(E) mapFifth,
+      R Function(F) mapSixth) {
     return _union.join(
         mapFirst, mapSecond, mapThird, mapFourth, mapFifth, mapSixth);
   }
 
-
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union6Impl &&
-              runtimeType == other.runtimeType &&
-              _union == other._union;
+      other is Union6Impl &&
+          runtimeType == other.runtimeType &&
+          _union == other._union;
 
   @override
   int get hashCode => _union.hashCode;

--- a/lib/implementations/union_7_impl.dart
+++ b/lib/implementations/union_7_impl.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_7.dart';
 
 class Union7Impl<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
@@ -7,10 +6,14 @@ class Union7Impl<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
   Union7Impl(Union7<A, B, C, D, E, F, G> union) : _union = union;
 
   @override
-  void continued(VoidFunc1<A> continuationFirst,
-      VoidFunc1<B> continuationSecond, VoidFunc1<C> continuationThird,
-      VoidFunc1<D> continuationFourth, VoidFunc1<E> continuationFifth,
-      VoidFunc1<F> continuationSixth, VoidFunc1<G> continuationSeventh) {
+  void continued(
+      Function(A) continuationFirst,
+      Function(B) continuationSecond,
+      Function(C) continuationThird,
+      Function(D) continuationFourth,
+      Function(E) continuationFifth,
+      Function(F) continuationSixth,
+      Function(G) continuationSeventh) {
     _union.continued(
         continuationFirst,
         continuationSecond,
@@ -22,25 +25,24 @@ class Union7Impl<A, B, C, D, E, F, G> implements Union7<A, B, C, D, E, F, G> {
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh) {
-    return _union.join(
-        mapFirst,
-        mapSecond,
-        mapThird,
-        mapFourth,
-        mapFifth,
-        mapSixth,
-        mapSeventh);
+  R join<R>(
+      R Function(A) mapFirst,
+      R Function(B) mapSecond,
+      R Function(C) mapThird,
+      R Function(D) mapFourth,
+      R Function(E) mapFifth,
+      R Function(F) mapSixth,
+      R Function(G) mapSeventh) {
+    return _union.join(mapFirst, mapSecond, mapThird, mapFourth, mapFifth,
+        mapSixth, mapSeventh);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union7Impl &&
-              runtimeType == other.runtimeType &&
-              _union == other._union;
+      other is Union7Impl &&
+          runtimeType == other.runtimeType &&
+          _union == other._union;
 
   @override
   int get hashCode => _union.hashCode;

--- a/lib/implementations/union_8_impl.dart
+++ b/lib/implementations/union_8_impl.dart
@@ -1,17 +1,21 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_8.dart';
 
-class Union8Impl<A, B, C, D, E, F, G, H> implements Union8<A, B, C, D, E, F, G, H> {
+class Union8Impl<A, B, C, D, E, F, G, H>
+    implements Union8<A, B, C, D, E, F, G, H> {
   final Union8<A, B, C, D, E, F, G, H> _union;
 
   Union8Impl(Union8<A, B, C, D, E, F, G, H> union) : _union = union;
 
   @override
-  void continued(VoidFunc1<A> continuationFirst,
-      VoidFunc1<B> continuationSecond, VoidFunc1<C> continuationThird,
-      VoidFunc1<D> continuationFourth, VoidFunc1<E> continuationFifth,
-      VoidFunc1<F> continuationSixth, VoidFunc1<G> continuationSeventh,
-      VoidFunc1<H> continuationEighth) {
+  void continued(
+      Function(A) continuationFirst,
+      Function(B) continuationSecond,
+      Function(C) continuationThird,
+      Function(D) continuationFourth,
+      Function(E) continuationFifth,
+      Function(F) continuationSixth,
+      Function(G) continuationSeventh,
+      Function(H) continuationEighth) {
     _union.continued(
         continuationFirst,
         continuationSecond,
@@ -24,27 +28,25 @@ class Union8Impl<A, B, C, D, E, F, G, H> implements Union8<A, B, C, D, E, F, G, 
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth) {
-    return _union.join(
-        mapFirst,
-        mapSecond,
-        mapThird,
-        mapFourth,
-        mapFifth,
-        mapSixth,
-        mapSeventh,
-        mapEighth);
+  R join<R>(
+      R Function(A) mapFirst,
+      R Function(B) mapSecond,
+      R Function(C) mapThird,
+      R Function(D) mapFourth,
+      R Function(E) mapFifth,
+      R Function(F) mapSixth,
+      R Function(G) mapSeventh,
+      R Function(H) mapEighth) {
+    return _union.join(mapFirst, mapSecond, mapThird, mapFourth, mapFifth,
+        mapSixth, mapSeventh, mapEighth);
   }
-
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union8Impl &&
-              runtimeType == other.runtimeType &&
-              _union == other._union;
+      other is Union8Impl &&
+          runtimeType == other.runtimeType &&
+          _union == other._union;
 
   @override
   int get hashCode => _union.hashCode;

--- a/lib/implementations/union_9_impl.dart
+++ b/lib/implementations/union_9_impl.dart
@@ -1,4 +1,3 @@
-import 'package:func/func.dart';
 import 'package:sealed_unions/union_9.dart';
 
 class Union9Impl<A, B, C, D, E, F, G, H, I>
@@ -8,11 +7,16 @@ class Union9Impl<A, B, C, D, E, F, G, H, I>
   Union9Impl(Union9<A, B, C, D, E, F, G, H, I> union) : _union = union;
 
   @override
-  void continued(VoidFunc1<A> continuationFirst,
-      VoidFunc1<B> continuationSecond, VoidFunc1<C> continuationThird,
-      VoidFunc1<D> continuationFourth, VoidFunc1<E> continuationFifth,
-      VoidFunc1<F> continuationSixth, VoidFunc1<G> continuationSeventh,
-      VoidFunc1<H> continuationEighth, VoidFunc1<I> continuationNinth) {
+  void continued(
+      Function(A) continuationFirst,
+      Function(B) continuationSecond,
+      Function(C) continuationThird,
+      Function(D) continuationFourth,
+      Function(E) continuationFifth,
+      Function(F) continuationSixth,
+      Function(G) continuationSeventh,
+      Function(H) continuationEighth,
+      Function(I) continuationNinth) {
     _union.continued(
         continuationFirst,
         continuationSecond,
@@ -26,27 +30,26 @@ class Union9Impl<A, B, C, D, E, F, G, H, I>
   }
 
   @override
-  R join<R>(Func1<A, R> mapFirst, Func1<B, R> mapSecond, Func1<C, R> mapThird,
-      Func1<D, R> mapFourth, Func1<E, R> mapFifth, Func1<F, R> mapSixth,
-      Func1<G, R> mapSeventh, Func1<H, R> mapEighth, Func1<I, R> mapNinth) {
-    return _union.join(
-        mapFirst,
-        mapSecond,
-        mapThird,
-        mapFourth,
-        mapFifth,
-        mapSixth,
-        mapSeventh,
-        mapEighth,
-        mapNinth);
+  R join<R>(
+      R Function(A) mapFirst,
+      R Function(B) mapSecond,
+      R Function(C) mapThird,
+      R Function(D) mapFourth,
+      R Function(E) mapFifth,
+      R Function(F) mapSixth,
+      R Function(G) mapSeventh,
+      R Function(H) mapEighth,
+      R Function(I) mapNinth) {
+    return _union.join(mapFirst, mapSecond, mapThird, mapFourth, mapFifth,
+        mapSixth, mapSeventh, mapEighth, mapNinth);
   }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Union9Impl &&
-              runtimeType == other.runtimeType &&
-              _union == other._union;
+      other is Union9Impl &&
+          runtimeType == other.runtimeType &&
+          _union == other._union;
 
   @override
   int get hashCode => _union.hashCode;

--- a/lib/sealed_unions.dart
+++ b/lib/sealed_unions.dart
@@ -1,16 +1,5 @@
-
 library sealed_unions;
 
-export 'union_0.dart';
-export 'union_1.dart';
-export 'union_2.dart';
-export 'union_3.dart';
-export 'union_4.dart';
-export 'union_5.dart';
-export 'union_6.dart';
-export 'union_7.dart';
-export 'union_8.dart';
-export 'union_9.dart';
 export 'factories/doublet_factory.dart';
 export 'factories/nonet_factory.dart';
 export 'factories/nullet_factory.dart';
@@ -78,3 +67,13 @@ export 'implementations/union_6_impl.dart';
 export 'implementations/union_7_impl.dart';
 export 'implementations/union_8_impl.dart';
 export 'implementations/union_9_impl.dart';
+export 'union_0.dart';
+export 'union_1.dart';
+export 'union_2.dart';
+export 'union_3.dart';
+export 'union_4.dart';
+export 'union_5.dart';
+export 'union_6.dart';
+export 'union_7.dart';
+export 'union_8.dart';
+export 'union_9.dart';

--- a/lib/union_0.dart
+++ b/lib/union_0.dart
@@ -1,22 +1,15 @@
-import 'package:func/func.dart';
-
-
 ///
 /// Union1 represents a union containing an element of 1 possible type
 ///
 /// @param <First> The type represented by this union
 ///
-abstract class Union0<First>{
-
+abstract class Union0<First> {
   /// Executes one of the continuations depending on the element type
-  void continued(VoidFunc1<First> continuationFirst);
+  void continued(Function(First) continuationFirst);
 
   /// Transforms the element in the union to a new type
   ///
   /// @param <R> result type
   /// @return an object of the result type
-  R join<R>(Func1<First, R> mapFirst);
-
+  R join<R>(R Function(First) mapFirst);
 }
-
-

--- a/lib/union_1.dart
+++ b/lib/union_1.dart
@@ -1,10 +1,8 @@
-import 'package:func/func.dart';
-
 abstract class Union1<First> {
   void continued(
-    VoidFunc1<First> continuationFirst,
-    VoidFunc0 continuationNone,
+    Function(First) continuationFirst,
+    Function() continuationNone,
   );
 
-  R join<R>(Func1<First, R> mapFirst, Func0<R> mapNone);
+  R join<R>(R Function(First) mapFirst, R Function() mapNone);
 }

--- a/lib/union_2.dart
+++ b/lib/union_2.dart
@@ -1,10 +1,8 @@
-import 'package:func/func.dart';
-
 abstract class Union2<First, Second> {
   void continued(
-    VoidFunc1<First> continuationFirst,
-    VoidFunc1<Second> continuationSecond,
+    Function(First) continuationFirst,
+    Function(Second) continuationSecond,
   );
 
-  R join<R>(Func1<First, R> mapFirst, Func1<Second, R> mapSecond);
+  R join<R>(R Function(First) mapFirst, R Function(Second) mapSecond);
 }

--- a/lib/union_3.dart
+++ b/lib/union_3.dart
@@ -1,15 +1,13 @@
-import 'package:func/func.dart';
-
 abstract class Union3<First, Second, Third> {
   void continued(
-    VoidFunc1<First> continuationFirst,
-    VoidFunc1<Second> continuationSecond,
-    VoidFunc1<Third> continuationThird,
+    Function(First) continuationFirst,
+    Function(Second) continuationSecond,
+    Function(Third) continuationThird,
   );
 
   R join<R>(
-    Func1<First, R> mapFirst,
-    Func1<Second, R> mapSecond,
-    Func1<Third, R> mapThird,
+    R Function(First) mapFirst,
+    R Function(Second) mapSecond,
+    R Function(Third) mapThird,
   );
 }

--- a/lib/union_4.dart
+++ b/lib/union_4.dart
@@ -1,17 +1,15 @@
-import 'package:func/func.dart';
-
 abstract class Union4<First, Second, Third, Fourth> {
   void continued(
-    VoidFunc1<First> continuationFirst,
-    VoidFunc1<Second> continuationSecond,
-    VoidFunc1<Third> continuationThird,
-    VoidFunc1<Fourth> continuationFourth,
+    Function(First) continuationFirst,
+    Function(Second) continuationSecond,
+    Function(Third) continuationThird,
+    Function(Fourth) continuationFourth,
   );
 
   R join<R>(
-    Func1<First, R> mapFirst,
-    Func1<Second, R> mapSecond,
-    Func1<Third, R> mapThird,
-    Func1<Fourth, R> mapFourth,
+    R Function(First) mapFirst,
+    R Function(Second) mapSecond,
+    R Function(Third) mapThird,
+    R Function(Fourth) mapFourth,
   );
 }

--- a/lib/union_5.dart
+++ b/lib/union_5.dart
@@ -1,19 +1,17 @@
-import 'package:func/func.dart';
-
 abstract class Union5<First, Second, Third, Fourth, Fifth> {
   void continued(
-    VoidFunc1<First> continuationFirst,
-    VoidFunc1<Second> continuationSecond,
-    VoidFunc1<Third> continuationThird,
-    VoidFunc1<Fourth> continuationFourth,
-    VoidFunc1<Fifth> continuationFifth,
+    Function(First) continuationFirst,
+    Function(Second) continuationSecond,
+    Function(Third) continuationThird,
+    Function(Fourth) continuationFourth,
+    Function(Fifth) continuationFifth,
   );
 
   R join<R>(
-    Func1<First, R> mapFirst,
-    Func1<Second, R> mapSecond,
-    Func1<Third, R> mapThird,
-    Func1<Fourth, R> mapFourth,
-    Func1<Fifth, R> mapFifth,
+    R Function(First) mapFirst,
+    R Function(Second) mapSecond,
+    R Function(Third) mapThird,
+    R Function(Fourth) mapFourth,
+    R Function(Fifth) mapFifth,
   );
 }

--- a/lib/union_6.dart
+++ b/lib/union_6.dart
@@ -1,21 +1,19 @@
-import 'package:func/func.dart';
-
 abstract class Union6<First, Second, Third, Fourth, Fifth, Sixth> {
   void continued(
-    VoidFunc1<First> continuationFirst,
-    VoidFunc1<Second> continuationSecond,
-    VoidFunc1<Third> continuationThird,
-    VoidFunc1<Fourth> continuationFourth,
-    VoidFunc1<Fifth> continuationFifth,
-    VoidFunc1<Sixth> continuationSixth,
+    Function(First) continuationFirst,
+    Function(Second) continuationSecond,
+    Function(Third) continuationThird,
+    Function(Fourth) continuationFourth,
+    Function(Fifth) continuationFifth,
+    Function(Sixth) continuationSixth,
   );
 
   R join<R>(
-    Func1<First, R> mapFirst,
-    Func1<Second, R> mapSecond,
-    Func1<Third, R> mapThird,
-    Func1<Fourth, R> mapFourth,
-    Func1<Fifth, R> mapFifth,
-    Func1<Sixth, R> mapSixth,
+    R Function(First) mapFirst,
+    R Function(Second) mapSecond,
+    R Function(Third) mapThird,
+    R Function(Fourth) mapFourth,
+    R Function(Fifth) mapFifth,
+    R Function(Sixth) mapSixth,
   );
 }

--- a/lib/union_7.dart
+++ b/lib/union_7.dart
@@ -1,22 +1,20 @@
-import 'package:func/func.dart';
-
 abstract class Union7<First, Second, Third, Fourth, Fifth, Sixth, Seventh> {
   void continued(
-      VoidFunc1<First> continuationFirst,
-      VoidFunc1<Second> continuationSecond,
-      VoidFunc1<Third> continuationThird,
-      VoidFunc1<Fourth> continuationFourth,
-      VoidFunc1<Fifth> continuationFifth,
-      VoidFunc1<Sixth> continuationSixth,
-      VoidFunc1<Seventh> continuationSeventh);
+      Function(First) continuationFirst,
+      Function(Second) continuationSecond,
+      Function(Third) continuationThird,
+      Function(Fourth) continuationFourth,
+      Function(Fifth) continuationFifth,
+      Function(Sixth) continuationSixth,
+      Function(Seventh) continuationSeventh);
 
   R join<R>(
-    Func1<First, R> mapFirst,
-    Func1<Second, R> mapSecond,
-    Func1<Third, R> mapThird,
-    Func1<Fourth, R> mapFourth,
-    Func1<Fifth, R> mapFifth,
-    Func1<Sixth, R> mapSixth,
-    Func1<Seventh, R> mapSeventh,
+    R Function(First) mapFirst,
+    R Function(Second) mapSecond,
+    R Function(Third) mapThird,
+    R Function(Fourth) mapFourth,
+    R Function(Fifth) mapFifth,
+    R Function(Sixth) mapSixth,
+    R Function(Seventh) mapSeventh,
   );
 }

--- a/lib/union_8.dart
+++ b/lib/union_8.dart
@@ -1,26 +1,24 @@
-import 'package:func/func.dart';
-
 abstract class Union8<First, Second, Third, Fourth, Fifth, Sixth, Seventh,
     Eighth> {
   void continued(
-    VoidFunc1<First> continuationFirst,
-    VoidFunc1<Second> continuationSecond,
-    VoidFunc1<Third> continuationThird,
-    VoidFunc1<Fourth> continuationFourth,
-    VoidFunc1<Fifth> continuationFifth,
-    VoidFunc1<Sixth> continuationSixth,
-    VoidFunc1<Seventh> continuationSeventh,
-    VoidFunc1<Eighth> continuationEighth,
+    Function(First) continuationFirst,
+    Function(Second) continuationSecond,
+    Function(Third) continuationThird,
+    Function(Fourth) continuationFourth,
+    Function(Fifth) continuationFifth,
+    Function(Sixth) continuationSixth,
+    Function(Seventh) continuationSeventh,
+    Function(Eighth) continuationEighth,
   );
 
   R join<R>(
-    Func1<First, R> mapFirst,
-    Func1<Second, R> mapSecond,
-    Func1<Third, R> mapThird,
-    Func1<Fourth, R> mapFourth,
-    Func1<Fifth, R> mapFifth,
-    Func1<Sixth, R> mapSixth,
-    Func1<Seventh, R> mapSeventh,
-    Func1<Eighth, R> mapEighth,
+    R Function(First) mapFirst,
+    R Function(Second) mapSecond,
+    R Function(Third) mapThird,
+    R Function(Fourth) mapFourth,
+    R Function(Fifth) mapFifth,
+    R Function(Sixth) mapSixth,
+    R Function(Seventh) mapSeventh,
+    R Function(Eighth) mapEighth,
   );
 }

--- a/lib/union_9.dart
+++ b/lib/union_9.dart
@@ -1,28 +1,26 @@
-import 'package:func/func.dart';
-
 abstract class Union9<First, Second, Third, Fourth, Fifth, Sixth, Seventh,
     Eighth, Ninth> {
   void continued(
-    VoidFunc1<First> continuationFirst,
-    VoidFunc1<Second> continuationSecond,
-    VoidFunc1<Third> continuationThird,
-    VoidFunc1<Fourth> continuationFourth,
-    VoidFunc1<Fifth> continuationFifth,
-    VoidFunc1<Sixth> continuationSixth,
-    VoidFunc1<Seventh> continuationSeventh,
-    VoidFunc1<Eighth> continuationEighth,
-    VoidFunc1<Ninth> continuationNinth,
+    Function(First) continuationFirst,
+    Function(Second) continuationSecond,
+    Function(Third) continuationThird,
+    Function(Fourth) continuationFourth,
+    Function(Fifth) continuationFifth,
+    Function(Sixth) continuationSixth,
+    Function(Seventh) continuationSeventh,
+    Function(Eighth) continuationEighth,
+    Function(Ninth) continuationNinth,
   );
 
   R join<R>(
-    Func1<First, R> mapFirst,
-    Func1<Second, R> mapSecond,
-    Func1<Third, R> mapThird,
-    Func1<Fourth, R> mapFourth,
-    Func1<Fifth, R> mapFifth,
-    Func1<Sixth, R> mapSixth,
-    Func1<Seventh, R> mapSeventh,
-    Func1<Eighth, R> mapEighth,
-    Func1<Ninth, R> mapNinth,
+    R Function(First) mapFirst,
+    R Function(Second) mapSecond,
+    R Function(Third) mapThird,
+    R Function(Fourth) mapFourth,
+    R Function(Fifth) mapFifth,
+    R Function(Sixth) mapSixth,
+    R Function(Seventh) mapSeventh,
+    R Function(Eighth) mapEighth,
+    R Function(Ninth) mapNinth,
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,13 +2,10 @@ name: sealed_unions
 author: Flutter Consortium Team <contact+gh@androidalliance.co.uk>
 description: Sealed Unions for Dart
 homepage: https://github.com/flutterconsortium/dart_sealed_unions
-version: 2.0.0
+version: 3.0.0
 
 environment:
-  sdk: '>=1.24.0 <2.0.0'
-
-dependencies:
-  func: "^1.0.0"
+  sdk: '>=2.0.0 <3.0.0'
 
 dev_dependencies:
-  test: "^0.12.4+5"
+  test: "^1.3.0"

--- a/test/union_factories_test.dart
+++ b/test/union_factories_test.dart
@@ -8,22 +8,30 @@ import 'package:sealed_unions/factories/septet_factory.dart';
 import 'package:sealed_unions/factories/sextet_factory.dart';
 import 'package:sealed_unions/factories/singlet_factory.dart';
 import 'package:sealed_unions/factories/triplet_factory.dart';
-import 'package:func/func.dart';
-import 'package:test/test.dart' hide Func0, Func1, Func2, Func3, Func4, Func5, Func6;
+import 'package:test/test.dart'
+    hide Func0, Func1, Func2, Func3, Func4, Func5, Func6;
 
 const String VALID = "a";
 const String INVALID = "";
-const List<String>VALID_ARRAY = const[
-  VALID, VALID, VALID, VALID, VALID, VALID, VALID, VALID, VALID, VALID
+const List<String> VALID_ARRAY = const [
+  VALID,
+  VALID,
+  VALID,
+  VALID,
+  VALID,
+  VALID,
+  VALID,
+  VALID,
+  VALID,
+  VALID
 ];
 
-final Func1<int, String> VALUE = (a) => VALID;
-final Func1<int, String> EMPTY = (a) => INVALID;
-final VoidFunc1<int> SUCCESS = (i) => "Success";
-final VoidFunc1<int> ERROR = (i) => new StateError("");
+final String Function(int) VALUE = (a) => VALID;
+final String Function(int) EMPTY = (a) => INVALID;
+final Function(int) SUCCESS = (i) => "Success";
+final Function(int) ERROR = (i) => new StateError("");
 
 void main() {
-
   group('Union Factories => test join ', () {
     Nullet<int> nullet = new Nullet();
     Singlet<int> singlet = new Singlet();
@@ -42,107 +50,235 @@ void main() {
     String join3 = triplet.first(0).join(VALUE, VALUE, VALUE);
     String join4 = quartet.first(0).join(VALUE, VALUE, VALUE, VALUE);
     String join5 = quintet.first(0).join(VALUE, VALUE, VALUE, VALUE, VALUE);
-    String join6 = sextet.first(0).join(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
-    String join7 = septet.first(0).join(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
-    String join8 = octet.first(0).join(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
-    String join9 = nonet.first(0).join(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
+    String join6 =
+        sextet.first(0).join(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
+    String join7 =
+        septet.first(0).join(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
+    String join8 = octet
+        .first(0)
+        .join(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
+    String join9 = nonet
+        .first(0)
+        .join(VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE, VALUE);
 
     test('assert valid array => first', () {
-      expect(VALID_ARRAY,
-          [join0, join1, join2, join3, join4, join5, join6, join7, join8, join9]);
+      expect(VALID_ARRAY, [
+        join0,
+        join1,
+        join2,
+        join3,
+        join4,
+        join5,
+        join6,
+        join7,
+        join8,
+        join9
+      ]);
     });
 
-    join1 = singlet.none().join(EMPTY, ()=>VALID);
-    join2 = doublet.second(0).join((a)=>INVALID, (a)=>VALID);
+    join1 = singlet.none().join(EMPTY, () => VALID);
+    join2 = doublet.second(0).join((a) => INVALID, (a) => VALID);
     join3 = triplet.second(0).join(EMPTY, VALUE, EMPTY);
     join4 = quartet.second(0).join(EMPTY, VALUE, EMPTY, EMPTY);
     join5 = quintet.second(0).join(EMPTY, VALUE, EMPTY, EMPTY, EMPTY);
     join6 = sextet.second(0).join(EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY);
-    join7 = septet.second(0).join(EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
-    join8 = octet.second(0).join(EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
-    join9 = nonet.second(0).join(EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
+    join7 =
+        septet.second(0).join(EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
+    join8 = octet
+        .second(0)
+        .join(EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
+    join9 = nonet
+        .second(0)
+        .join(EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
 
     test('assert valid array => second', () {
-      expect(VALID_ARRAY,
-          [join0, join1, join2, join3, join4, join5, join6, join7, join8, join9]);
+      expect(VALID_ARRAY, [
+        join0,
+        join1,
+        join2,
+        join3,
+        join4,
+        join5,
+        join6,
+        join7,
+        join8,
+        join9
+      ]);
     });
-
 
     join3 = triplet.third(0).join(EMPTY, EMPTY, VALUE);
     join4 = quartet.third(0).join(EMPTY, EMPTY, VALUE, EMPTY);
     join5 = quintet.third(0).join(EMPTY, EMPTY, VALUE, EMPTY, EMPTY);
     join6 = sextet.third(0).join(EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY);
-    join7 = septet.third(0).join(EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY);
-    join8 = octet.third(0).join(EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
-    join9 = nonet.third(0).join(EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY,EMPTY);
+    join7 =
+        septet.third(0).join(EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY);
+    join8 = octet
+        .third(0)
+        .join(EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
+    join9 = nonet
+        .third(0)
+        .join(EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
 
     test('assert valid array => third', () {
-      expect(VALID_ARRAY,
-          [join0, join1, join2, join3, join4, join5, join6, join7, join8, join9]);
+      expect(VALID_ARRAY, [
+        join0,
+        join1,
+        join2,
+        join3,
+        join4,
+        join5,
+        join6,
+        join7,
+        join8,
+        join9
+      ]);
     });
 
     join4 = quartet.fourth(0).join(EMPTY, EMPTY, EMPTY, VALUE);
     join5 = quintet.fourth(0).join(EMPTY, EMPTY, EMPTY, VALUE, EMPTY);
     join6 = sextet.fourth(0).join(EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY);
-    join7 = septet.fourth(0).join(EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY);
-    join8 = octet.fourth(0).join(EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY);
-    join9 = nonet.fourth(0).join(EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
+    join7 =
+        septet.fourth(0).join(EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY);
+    join8 = octet
+        .fourth(0)
+        .join(EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY);
+    join9 = nonet
+        .fourth(0)
+        .join(EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY);
 
     test('assert valid array => fourth', () {
-      expect(VALID_ARRAY,
-          [join0, join1, join2, join3, join4, join5, join6, join7, join8, join9]);
+      expect(VALID_ARRAY, [
+        join0,
+        join1,
+        join2,
+        join3,
+        join4,
+        join5,
+        join6,
+        join7,
+        join8,
+        join9
+      ]);
     });
 
     join5 = quintet.fifth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, VALUE);
     join6 = sextet.fifth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY);
-    join7 = septet.fifth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY);
-    join8 = octet.fifth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY);
-    join9 = nonet.fifth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY);
+    join7 =
+        septet.fifth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY);
+    join8 = octet
+        .fifth(0)
+        .join(EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY);
+    join9 = nonet
+        .fifth(0)
+        .join(EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY, EMPTY);
 
     test('assert valid array => fifth', () {
-      expect(VALID_ARRAY,
-          [join0, join1, join2, join3, join4, join5, join6, join7, join8, join9]);
+      expect(VALID_ARRAY, [
+        join0,
+        join1,
+        join2,
+        join3,
+        join4,
+        join5,
+        join6,
+        join7,
+        join8,
+        join9
+      ]);
     });
 
     join6 = sextet.sixth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE);
-    join7 = septet.sixth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY);
-    join8 = octet.sixth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY);
-    join9 = nonet.sixth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY);
+    join7 =
+        septet.sixth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY);
+    join8 = octet
+        .sixth(0)
+        .join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY);
+    join9 = nonet
+        .sixth(0)
+        .join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY, EMPTY);
 
     test('assert valid array => sixth', () {
-      expect(VALID_ARRAY,
-          [join0, join1, join2, join3, join4, join5, join6, join7, join8, join9]);
+      expect(VALID_ARRAY, [
+        join0,
+        join1,
+        join2,
+        join3,
+        join4,
+        join5,
+        join6,
+        join7,
+        join8,
+        join9
+      ]);
     });
 
-    join7 = septet.seventh(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE);
-    join8 = octet.seventh(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY);
-    join9 = nonet.seventh(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY);
+    join7 =
+        septet.seventh(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE);
+    join8 = octet
+        .seventh(0)
+        .join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY);
+    join9 = nonet
+        .seventh(0)
+        .join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY, EMPTY);
 
     test('assert valid array => septet', () {
-      expect(VALID_ARRAY,
-          [join0, join1, join2, join3, join4, join5, join6, join7, join8, join9]);
+      expect(VALID_ARRAY, [
+        join0,
+        join1,
+        join2,
+        join3,
+        join4,
+        join5,
+        join6,
+        join7,
+        join8,
+        join9
+      ]);
     });
 
-    join8 = octet.eighth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE);
-    join9 = nonet.eighth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY);
+    join8 = octet
+        .eighth(0)
+        .join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE);
+    join9 = nonet
+        .eighth(0)
+        .join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE, EMPTY);
 
     test('assert valid array => eighth', () {
-      expect(VALID_ARRAY,
-          [join0, join1, join2, join3, join4, join5, join6, join7, join8, join9]);
+      expect(VALID_ARRAY, [
+        join0,
+        join1,
+        join2,
+        join3,
+        join4,
+        join5,
+        join6,
+        join7,
+        join8,
+        join9
+      ]);
     });
 
-    join9 = nonet.ninth(0).join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE);
+    join9 = nonet
+        .ninth(0)
+        .join(EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, VALUE);
 
     test('assert valid array => ninth', () {
-      expect(VALID_ARRAY,
-          [join0, join1, join2, join3, join4, join5, join6, join7, join8, join9]);
+      expect(VALID_ARRAY, [
+        join0,
+        join1,
+        join2,
+        join3,
+        join4,
+        join5,
+        join6,
+        join7,
+        join8,
+        join9
+      ]);
     });
-
   });
 
-
   group('Union Factories => test continued ', () {
-
     Nullet<int> nullet = new Nullet();
     Singlet<int> singlet = new Singlet();
     Doublet<int, int> doublet = new Doublet();
@@ -155,59 +291,98 @@ void main() {
     Nonet<int, int, int, int, int, int, int, int, int> nonet = new Nonet();
 
     nullet.first(0).continued(SUCCESS);
-    singlet.first(0).continued(SUCCESS, (){});
+    singlet.first(0).continued(SUCCESS, () {});
     doublet.first(0).continued(SUCCESS, ERROR);
     triplet.first(0).continued(SUCCESS, ERROR, ERROR);
     quartet.first(0).continued(SUCCESS, ERROR, ERROR, ERROR);
     quintet.first(0).continued(SUCCESS, ERROR, ERROR, ERROR, ERROR);
     sextet.first(0).continued(SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR);
-    septet.first(0).continued(SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
-    octet.first(0).continued(SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
-    nonet.first(0).continued(SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
+    septet
+        .first(0)
+        .continued(SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
+    octet
+        .first(0)
+        .continued(SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
+    nonet.first(0).continued(
+        SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
     /* */
-    singlet.none().continued(ERROR, (){});
+    singlet.none().continued(ERROR, () {});
     doublet.second(0).continued(ERROR, SUCCESS);
     triplet.second(0).continued(ERROR, SUCCESS, ERROR);
     quartet.second(0).continued(ERROR, SUCCESS, ERROR, ERROR);
     quintet.second(0).continued(ERROR, SUCCESS, ERROR, ERROR, ERROR);
     sextet.second(0).continued(ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR);
-    septet.second(0).continued(ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR);
-    octet.second(0).continued(ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
-    nonet.second(0).continued(ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
+    septet
+        .second(0)
+        .continued(ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR);
+    octet
+        .second(0)
+        .continued(ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
+    nonet.second(0).continued(
+        ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
     /* */
     triplet.third(0).continued(ERROR, ERROR, SUCCESS);
     quartet.third(0).continued(ERROR, ERROR, SUCCESS, ERROR);
     quintet.third(0).continued(ERROR, ERROR, SUCCESS, ERROR, ERROR);
     sextet.third(0).continued(ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR);
-    septet.third(0).continued(ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR);
-    octet.third(0).continued(ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR);
-    nonet.third(0).continued(ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
+    septet
+        .third(0)
+        .continued(ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR);
+    octet
+        .third(0)
+        .continued(ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR);
+    nonet.third(0).continued(
+        ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR);
     /* */
     quartet.fourth(0).continued(ERROR, ERROR, ERROR, SUCCESS);
     quintet.fourth(0).continued(ERROR, ERROR, ERROR, SUCCESS, ERROR);
     sextet.fourth(0).continued(ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR);
-    septet.fourth(0).continued(ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR);
-    octet.fourth(0).continued(ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR);
-    nonet.fourth(0).continued(ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR);
+    septet
+        .fourth(0)
+        .continued(ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR);
+    octet
+        .fourth(0)
+        .continued(ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR);
+    nonet.fourth(0).continued(
+        ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR, ERROR);
     /* */
     quintet.fifth(0).continued(ERROR, ERROR, ERROR, ERROR, SUCCESS);
     sextet.fifth(0).continued(ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR);
-    septet.fifth(0).continued(ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR);
-    octet.fifth(0).continued(ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR);
-    nonet.fifth(0).continued(ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR);
+    septet
+        .fifth(0)
+        .continued(ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR);
+    octet
+        .fifth(0)
+        .continued(ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR);
+    nonet.fifth(0).continued(
+        ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR, ERROR);
     /* */
     sextet.sixth(0).continued(ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS);
-    septet.sixth(0).continued(ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR);
-    octet.sixth(0).continued(ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR);
-    nonet.sixth(0).continued(ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR);
+    septet
+        .sixth(0)
+        .continued(ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR);
+    octet
+        .sixth(0)
+        .continued(ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR);
+    nonet.sixth(0).continued(
+        ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR, ERROR);
     /* */
-    septet.seventh(0).continued(ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS);
-    octet.seventh(0).continued(ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR);
-    nonet.seventh(0).continued(ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR);
+    septet
+        .seventh(0)
+        .continued(ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS);
+    octet
+        .seventh(0)
+        .continued(ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR);
+    nonet.seventh(0).continued(
+        ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR, ERROR);
     /* */
-    octet.eighth(0).continued(ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS);
-    nonet.eighth(0).continued(ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR);
+    octet
+        .eighth(0)
+        .continued(ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS);
+    nonet.eighth(0).continued(
+        ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS, ERROR);
     /* */
-    nonet.ninth(0).continued(ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS);
+    nonet.ninth(0).continued(
+        ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, ERROR, SUCCESS);
   });
 }


### PR DESCRIPTION
  * Update SDK Constraint
  * Removes func package (deprecated)
  * Uses plain ol' Dart syntax
  * Ran Dartfmt on everything
  * Updated Changelog and pubspec version

Fixes #5 