### PR TITLE
Migrate to null safety

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: sealed_unions
 description: Sealed Unions for Dart
-version: 3.0.2+2
+version: 4.0.0
 maintainer: George Medve (@nodinosaur)
-authors: 
+authors:
 - Flutter Community <community@flutter.zone>
 - George Medve <contact+gh@androidalliance.co.uk>
 homepage: https://github.com/fluttercommunity/dart_sealed_unions
 documentation:
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
-  test: "^1.3.3"
+  test: "^1.6.5"


### PR DESCRIPTION
Note that `tennis` has not been migrated, only sealed unions.

Since updating the sdk constraints have updated (as indicated here: https://dart.dev/null-safety#enable-null-safety), compilation succeeds and all tests pass, I believe there are no real changes needed for the migration.

Thanks a lot :)